### PR TITLE
GraphQL - Fix urlResolver query to support relative path

### DIFF
--- a/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite.php
+++ b/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite.php
@@ -15,6 +15,7 @@ use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\UrlRewrite\Model\UrlFinderInterface;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Cms\Helper\Page;
 
 /**
  * UrlRewrite field resolver, used for GraphQL request processing.
@@ -41,7 +42,6 @@ class UrlRewrite implements ResolverInterface
      */
     private $scopeConfig;
     
-
     /**
      * @param UrlFinderInterface $urlFinder
      * @param StoreManagerInterface $storeManager
@@ -80,7 +80,7 @@ class UrlRewrite implements ResolverInterface
                 $url = ltrim($url, '/');
             } else if ($url === '/') {
                 $homePageIdentifier = $this->scopeConfig->getValue(
-                    \Magento\Cms\Helper\Page::XML_PATH_HOME_PAGE,
+                    Page::XML_PATH_HOME_PAGE,
                     ScopeInterface::SCOPE_STORE
                 );
                 $url = $homePageIdentifier;

--- a/app/code/Magento/UrlRewriteGraphQl/composer.json
+++ b/app/code/Magento/UrlRewriteGraphQl/composer.json
@@ -1,27 +1,27 @@
 {
-    "name": "magento/module-url-rewrite-graph-ql",
-    "description": "N/A",
-    "type": "magento2-module",
-    "require": {
-        "php": "~7.1.3||~7.2.0",
-        "magento/framework": "*",
-        "magento/module-url-rewrite": "*",
-        "magento/module-store": "*"
-
-    },
-    "suggest": {
-        "magento/module-graph-ql": "*"
-    },
-    "license": [
-        "OSL-3.0",
-        "AFL-3.0"
-    ],
-    "autoload": {
-        "files": [
-            "registration.php"
-        ],
-        "psr-4": {
-            "Magento\\UrlRewriteGraphQl\\": ""
-        }
-    }
+	"name" : "magento/module-url-rewrite-graph-ql",
+	"description" : "N/A",
+	"type" : "magento2-module",
+	"require" : {
+		"php" : "~7.1.3||~7.2.0",
+		"magento/framework" : "*",
+		"magento/module-url-rewrite" : "*",
+		"magento/module-store" : "*",
+		"magento/cms" : "*"
+	},
+	"suggest" : {
+		"magento/module-graph-ql" : "*"
+	},
+	"license" : [
+		"OSL-3.0",
+		"AFL-3.0"
+	],
+	"autoload" : {
+		"files" : [
+			"registration.php"
+		],
+		"psr-4" : {
+			"Magento\\UrlRewriteGraphQl\\" : ""
+		}
+	}
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/UrlRewrite/UrlResolverTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/UrlRewrite/UrlResolverTest.php
@@ -289,7 +289,7 @@ QUERY;
         $urlFinder = $this->objectManager->get(UrlFinderInterface::class);
         $actualUrls = $urlFinder->findOneByData(
             [
-                'request_path' => $urlPath,
+                'request_path' => $urlPath2,
                 'store_id' => $storeId
             ]
         );


### PR DESCRIPTION
### Description
Using the urlResolver query, sending a valid URL for the url field with leading / query returns the same result for the route that it would if the leading / was not present

### Fixed Issues (if relevant)
1. magento/graphql-ce#9: Fix urlResolver query to support relative path

### Manual testing scenarios
1. Run following query
`{
  urlResolver(url: "/") {
	  canonical_url
    id
    type
  }
}`
2. Magento should returns the same information when querying `url: "home"`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
