### PR TITLE
[fix] invalid reference to ContextExtensionInterface instead of Conte…

### DIFF
--- a/app/code/Magento/GraphQl/Model/Query/Resolver/Context.php
+++ b/app/code/Magento/GraphQl/Model/Query/Resolver/Context.php
@@ -66,9 +66,9 @@ class Context extends \Magento\Framework\Model\AbstractExtensibleModel implement
     /**
      * {@inheritdoc}
      *
-     * @return \Magento\Framework\GraphQl\Query\Resolver\ContextExtensionInterface
+     * @return \Magento\Framework\GraphQl\Query\Resolver\ContextInterface
      */
-    public function getExtensionAttributes() : \Magento\Framework\GraphQl\Query\Resolver\ContextExtensionInterface
+    public function getExtensionAttributes() : \Magento\Framework\GraphQl\Query\Resolver\ContextInterface
     {
         return $this->_getExtensionAttributes();
     }
@@ -76,11 +76,11 @@ class Context extends \Magento\Framework\Model\AbstractExtensibleModel implement
     /**
      * {@inheritdoc}
      *
-     * @param \Magento\Framework\GraphQl\Query\Resolver\ContextExtensionInterface $extensionAttributes
+     * @param \Magento\Framework\GraphQl\Query\Resolver\ContextInterface $extensionAttributes
      * @return ContextInterface
      */
     public function setExtensionAttributes(
-        \Magento\Framework\GraphQl\Query\Resolver\ContextExtensionInterface $extensionAttributes
+        \Magento\Framework\GraphQl\Query\Resolver\ContextInterface $extensionAttributes
     ) : ContextInterface {
         return $this->_setExtensionAttributes($extensionAttributes);
     }

--- a/lib/internal/Magento/Framework/GraphQl/Query/Resolver/ContextInterface.php
+++ b/lib/internal/Magento/Framework/GraphQl/Query/Resolver/ContextInterface.php
@@ -55,17 +55,17 @@ interface ContextInterface extends ExtensibleDataInterface
     /**
      * Retrieve existing extension attributes object or create a new one.
      *
-     * @return \Magento\Framework\GraphQl\Query\Resolver\ContextExtensionInterface
+     * @return \Magento\Framework\GraphQl\Query\Resolver\ContextInterface
      */
     public function getExtensionAttributes();
 
     /**
      * Set an extension attributes object.
      *
-     * @param \Magento\Framework\GraphQl\Query\Resolver\ContextExtensionInterface $extensionAttributes
+     * @param \Magento\Framework\GraphQl\Query\Resolver\ContextInterface $extensionAttributes
      * @return ContextInterface
      */
     public function setExtensionAttributes(
-        \Magento\Framework\GraphQl\Query\Resolver\ContextExtensionInterface $extensionAttributes
+        \Magento\Framework\GraphQl\Query\Resolver\ContextInterface $extensionAttributes
     ) : ContextInterface;
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
The GraphQL Context Model references to a non existent `ContextExtensionInterface` instead to the  `\Magento\Framework\GraphQl\Query\Resolver\ContextInterface`.

PR was originally created in magento/magento2 but got informed that it makes more sense here:
See Original PR: https://github.com/magento/magento2/pull/15250

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
