### PR TITLE
Include 'products' in category query

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Products.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Products.php
@@ -17,8 +17,7 @@ use Magento\Framework\GraphQl\Query\Resolver\Argument\SearchCriteria\Builder;
 use Magento\CatalogGraphQl\Model\Resolver\Products\Query\Filter;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 
-class Products
-    implements ResolverInterface
+class Products implements ResolverInterface
 {
     /** @var \Magento\Catalog\Api\ProductRepositoryInterface */
     private $productRepository;
@@ -102,5 +101,4 @@ class Products
 
         return $this->valueFactory->create($result);
     }
-
 }

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Products.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Products.php
@@ -17,6 +17,9 @@ use Magento\Framework\GraphQl\Query\Resolver\Argument\SearchCriteria\Builder;
 use Magento\CatalogGraphQl\Model\Resolver\Products\Query\Filter;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 
+/**
+ * Category products resolver, used by GraphQL endpoints to retrieve products assigned to a category
+ */
 class Products implements ResolverInterface
 {
     /** @var \Magento\Catalog\Api\ProductRepositoryInterface */

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Products.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Products.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogGraphQl\Model\Resolver\Category;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\Resolver\Value;
+use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\GraphQl\Query\Resolver\Argument\SearchCriteria\Builder;
+use Magento\CatalogGraphQl\Model\Resolver\Products\Query\Filter;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+
+class Products
+    implements ResolverInterface
+{
+    /** @var \Magento\Catalog\Api\ProductRepositoryInterface */
+    private $productRepository;
+
+    /** @var Builder */
+    private $searchCriteriaBuilder;
+
+    /** @var Filter */
+    private $filterQuery;
+
+    /** @var ValueFactory */
+    private $valueFactory;
+
+    /**
+     * @param ProductRepositoryInterface $productRepository
+     * @param Builder $searchCriteriaBuilder
+     * @param Filter $filterQuery
+     * @param ValueFactory $valueFactory
+     */
+    public function __construct(
+        ProductRepositoryInterface $productRepository,
+        Builder $searchCriteriaBuilder,
+        Filter $filterQuery,
+        ValueFactory $valueFactory
+    ) {
+        $this->productRepository = $productRepository;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->filterQuery = $filterQuery;
+        $this->valueFactory = $valueFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ): Value {
+        $args['filter'] = [
+            'category_ids' => [
+                'eq' => $value['id']
+            ]
+        ];
+        $searchCriteria = $this->searchCriteriaBuilder->build($field->getName(), $args);
+        $searchCriteria->setCurrentPage($args['currentPage']);
+        $searchCriteria->setPageSize($args['pageSize']);
+        $searchResult = $this->filterQuery->getResult($searchCriteria, $info);
+
+        //possible division by 0
+        if ($searchCriteria->getPageSize()) {
+            $maxPages = ceil($searchResult->getTotalCount() / $searchCriteria->getPageSize());
+        } else {
+            $maxPages = 0;
+        }
+
+        $currentPage = $searchCriteria->getCurrentPage();
+        if ($searchCriteria->getCurrentPage() > $maxPages && $searchResult->getTotalCount() > 0) {
+            $currentPage = new GraphQlInputException(
+                __(
+                    'currentPage value %1 specified is greater than the number of pages available.',
+                    [$maxPages]
+                )
+            );
+        }
+
+        $data = [
+            'total_count' => $searchResult->getTotalCount(),
+            'items'       => $searchResult->getProductsSearchResult(),
+            'page_info'   => [
+                'page_size'    => $searchCriteria->getPageSize(),
+                'current_page' => $currentPage
+            ]
+        ];
+
+        $result = function () use ($data) {
+            return $data;
+        };
+
+        return $this->valueFactory->create($result);
+    }
+
+}

--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -375,6 +375,11 @@ interface CategoryInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model
     updated_at: String @doc(description: "Timestamp indicating when the category was updated")
     product_count: Int @doc(description: "The number of products in the category")
     default_sort_by: String @doc(description: "The attribute to use for sorting")
+    products(
+        pageSize: Int = 20 @doc(description: "Specifies the maximum number of results to return at once. This attribute is optional."),
+        currentPage: Int = 1 @doc(description: "Specifies which page of results to return. The default value is 1."),
+        sort: ProductSortInput @doc(description: "Specifies which attribute to sort on, and whether to return the results in ascending or descending order.")
+    ): CategoryProducts @doc(description: "The list of products assigned to the category") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\Products")
 }
 
 type CustomizableRadioOption implements CustomizableOptionInterface @doc(description: "CustomizableRadioOption contains information about a set of radio buttons that are defined as part of a customizable option") {
@@ -402,6 +407,12 @@ type Products @doc(description: "The Products object is the top-level object ret
     page_info: SearchResultPageInfo @doc(description: "An object that includes the page_info and currentPage values specified in the query")
     total_count: Int @doc(description: "The number of products returned")
     filters: [LayerFilter] @doc(description: "Layered navigation filters array")
+}
+
+type CategoryProducts @doc(description: "The category products object returned in the Category query") {
+    items: [ProductInterface] @doc(description: "An array of products that match the specified search criteria")
+    page_info: SearchResultPageInfo @doc(description: "An object that includes the page_info and currentPage values specified in the query")
+    total_count: Int @doc(description: "The number of products returned")
 }
 
 input ProductFilterInput @doc(description: "ProductFilterInput defines the filters to be used in the search. A filter contains at least one attribute, a comparison operator, and the value that is being searched for.") {

--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -410,7 +410,7 @@ type Products @doc(description: "The Products object is the top-level object ret
 }
 
 type CategoryProducts @doc(description: "The category products object returned in the Category query") {
-    items: [ProductInterface] @doc(description: "An array of products that match the specified search criteria")
+    items: [ProductInterface] @doc(description: "An array of products that are assigned to the category")
     page_info: SearchResultPageInfo @doc(description: "An object that includes the page_info and currentPage values specified in the query")
     total_count: Int @doc(description: "The number of products returned")
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
@@ -327,7 +327,6 @@ QUERY;
             ['response_field' => 'sku', 'expected_value' => $product->getSku()],
             ['response_field' => 'type_id', 'expected_value' => $product->getTypeId()],
             ['response_field' => 'updated_at', 'expected_value' => $product->getUpdatedAt()],
-//            ['response_field' => 'weight', 'expected_value' => $product->getWeight()],
         ];
 
         $this->assertResponseFields($actualResponse, $assertionMap);
@@ -404,14 +403,5 @@ QUERY;
                 . var_export($expectedValue, true)
             );
         }
-    }
-
-    private function eavAttributesToGraphQlSchemaFieldTranslator($attributeCode)
-    {
-        if (isset($this->eavAttributesToGraphQlSchemaFieldMap[$attributeCode])) {
-            return $this->eavAttributesToGraphQlSchemaFieldMap[$attributeCode];
-        }
-
-        return $attributeCode;
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
@@ -9,6 +9,7 @@ namespace Magento\GraphQl\Catalog;
 
 use Magento\Framework\DataObject;
 use Magento\TestFramework\TestCase\GraphQlAbstract;
+use Magento\Catalog\Api\ProductRepositoryInterface;
 
 class CategoryTest extends GraphQlAbstract
 {
@@ -108,5 +109,164 @@ QUERY;
             5,
             $responseDataObject->getData('category/children/7/children/1/children/0/id')
         );
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/Catalog/_files/categories.php
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    public function testCategoryProducts()
+    {
+        $categoryId = 4;
+        $query = <<<QUERY
+{
+  category(id: {$categoryId}) {
+    products {
+      total_count
+      page_info {
+        current_page
+        page_size
+      }
+      items {
+        attribute_set_id
+        country_of_manufacture
+        created_at
+        description
+        gift_message_available
+        id
+        categories {
+          name
+          url_path
+          available_sort_by
+          level
+        }
+        image
+        image_label
+        meta_description
+        meta_keyword
+        meta_title
+        media_gallery_entries {
+          disabled
+          file
+          id
+          label
+          media_type
+          position
+          types
+          content {
+            base64_encoded_data
+            type
+            name
+          }
+          video_content {
+            media_type
+            video_description
+            video_metadata
+            video_provider
+            video_title
+            video_url
+          }
+        }
+        name
+        new_from_date
+        new_to_date
+        options_container
+       
+        price {
+          minimalPrice {
+            amount {
+              value
+              currency
+            }
+            adjustments {
+              amount {
+                value
+                currency
+              }
+              code
+              description
+            }
+          }
+          maximalPrice {
+            amount {
+              value
+              currency
+            }
+            adjustments {
+              amount {
+                value
+                currency
+              }
+              code
+              description
+            }
+          }
+          regularPrice {
+            amount {
+              value
+              currency
+            }
+            adjustments {
+              amount {
+                value
+                currency
+              }
+              code
+              description
+            }
+          }
+        }
+        product_links {
+          link_type
+          linked_product_sku
+          linked_product_type
+          position
+          sku
+        }
+        short_description
+        sku
+        small_image
+        small_image_label
+        special_from_date
+        special_price
+        special_to_date
+        swatch_image
+        tax_class_id
+        thumbnail
+        thumbnail_label
+        tier_price
+        tier_prices {
+          customer_group_id
+          percentage_value
+          qty
+          value
+          website_id
+        }
+        type_id
+        updated_at
+        url_key
+        url_path
+        websites {
+          id
+          name
+          code
+          sort_order
+          default_group_id
+          is_default
+        }
+        
+      }
+    }
+  }
+}
+QUERY;
+
+        $response = $this->graphQlQuery($query);
+        $this->assertArrayHasKey('products', $response['category']);
+        $this->assertArrayHasKey('total_count', $response['category']['products']);
+        $this->assertEquals(2, $response['category']['products']['total_count']);
+        $this->assertEquals(1, $response['category']['products']['page_info']['current_page']);
+        $this->assertEquals(20, $response['category']['products']['page_info']['page_size']);
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
@@ -376,7 +376,7 @@ QUERY;
             'special_to_date',
         ];
 
-        foreach($eavAttributes as $eavAttribute){
+        foreach ($eavAttributes as $eavAttribute) {
             $this->assertArrayHasKey($eavAttribute, $actualResponse);
         }
     }
@@ -408,7 +408,7 @@ QUERY;
 
     private function eavAttributesToGraphQlSchemaFieldTranslator($attributeCode)
     {
-        if(isset($this->eavAttributesToGraphQlSchemaFieldMap[$attributeCode])){
+        if (isset($this->eavAttributesToGraphQlSchemaFieldMap[$attributeCode])) {
             return $this->eavAttributesToGraphQlSchemaFieldMap[$attributeCode];
         }
 


### PR DESCRIPTION
### Description
As a Magento developer, I want to access the "products" directly from any category object so that it's easy for me to render products belonging to a category from that category object. 

**Acceptance criteria**
1. User can access products belonging to a category from that category object
1. There is a default limit on how many products are shown at a time so that performance is not hindered
1. User can access products beyond than those included in the default set by changing pagination or default pagesize
1. At least the following data is available: 
    * name
    * sku
    * product_type
    * description
    * short_description
    * media_gallery_entries (default medium or thumbnail image)
    * price (final calculated price)
    * review rating
    * custom_attribute (ex: featured, popular)
    * product_options
5. Changes are covered with web API functional tests. See [\Magento\GraphQl\Catalog\ProductViewTest::testQueryAllFieldsSimpleProduct](https://github.com/magento/magento2/blob/b3372064f574fd5aece0617009ee317db589febe/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductViewTest.php#L35) as an example.


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)