### PR TITLE
Wrong Last orders amount on dashboard

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Currency.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Currency.php
@@ -68,10 +68,7 @@ class Currency extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Abstra
         $this->_storeManager = $storeManager;
         $this->_currencyLocator = $currencyLocator;
         $this->_localeCurrency = $localeCurrency;
-        $defaultBaseCurrencyCode = $this->_scopeConfig->getValue(
-            \Magento\Directory\Model\Currency::XML_PATH_CURRENCY_BASE,
-            'default'
-        );
+        $defaultBaseCurrencyCode = $currencyLocator->getDefaultCurrency($this->_request);
         $this->_defaultBaseCurrency = $currencyFactory->create()->load($defaultBaseCurrencyCode);
     }
 


### PR DESCRIPTION
Wrong order amount on dashboard on Last orders listing when having more than one website with different currencies

### Original Pull Request
https://github.com/magento/magento2/pull/15536
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#15660: Wrong order amount on dashboard on Last orders listing when having more than one website with different currencies

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create 2 Websites with 1 store in each
2. Set Default website/store base currency as INR (Indian Rupee)
3. Set another website/store base currency as USD (US Dollar)
4. Place Order from both websites with with their default currencies.
5. Now go to Dashboard and set Store View as All Store Views
6. See Last Orders table and check order's total amounts and all mounts will be in INR (USD orders will be converted to INR with exchange rate
7. Now change Store View to USD currency website's store which have orders
8. See Last Orders table and check order's total amounts. You will find those amounts converted to again into INR to USD. But at this point orders are already in USD so no need to convert amounts

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)