### PR TITLE
removed category_ids and tax_class_id from filterable fields list

### DIFF
--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -441,7 +441,6 @@ input ProductFilterInput @doc(description: "ProductFilterInput defines the filte
     min_price: FilterTypeInput @doc(description:"The numeric minimal price of the product. Do not include the currency code.")
     max_price: FilterTypeInput @doc(description:"The numeric maximal price of the product. Do not include the currency code.")
     special_price: FilterTypeInput @doc(description:"The numeric special price of the product. Do not include the currency code.")
-    category_ids: FilterTypeInput @doc(description: "An array of category IDs the product belongs to")
     options_container: FilterTypeInput @doc(description: "If the product has multiple options, determines where they appear on the product page")
     required_options: FilterTypeInput @doc(description: "Indicates whether the product has required options")
     has_options: FilterTypeInput @doc(description: "Indicates whether additional attributes have been created for the product")

--- a/app/code/Magento/TaxGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/TaxGraphQl/etc/schema.graphqls
@@ -1,10 +1,6 @@
 # Copyright © Magento, Inc. All rights reserved.
 # See COPYING.txt for license details.
 
-input ProductFilterInput {
-    tax_class_id: FilterTypeInput
-}
-
 interface ProductInterface {
     tax_class_id: Int
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

Tested all attributes from the issue description.
Turns out most of fields mentioned, are not available for filtering already.
Only `category_ids` and `tax_class_id` and `price` were still filterable.
Removed, `category_ids` and `tax_class_id`.
`price` attribute is still filterable. Please confirm that should be removed.

1. magento/graphql-ce#26: Limit list of filterable product fields


To test the issue create HTTP request to magento-domain/graphql
with Body:
{
  "query": "{ products(filter: { attribute_code : { eq: \"2\" }}) {total_count}}"
}

Where attribute_code should be (`category_ids` or `tax_class_id`)
Magento should generate an exception with "Unknown field." message


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
