### PR TITLE
Absolute and relative path passed as argument return matching fields

### DIFF
--- a/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite.php
+++ b/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite.php
@@ -74,17 +74,20 @@ class UrlRewrite implements ResolverInterface
         };
         
         if (isset($args['url'])) {
-            $url = $args['url'];
-            if (substr($url, 0, 1) === '/' && $url !== '/') {
-                $url = ltrim($url, '/');
+            $parsedUrl = parse_url($args['url']);
+            $url = $parsedUrl['path'];
+            if ($parsedUrl['path'][0] === '/' && $parsedUrl['path'] !== '/') {
+                $url = ltrim($parsedUrl['path'], '/');
             }
             $customUrl = $this->customUrlLocator->locateUrl($url);
             $url = $customUrl ?: $url;
             $urlRewrite = $this->findCanonicalUrl($url);
+            $baseUrl = $this->storeManager->getStore()->getBaseUrl();
             if ($urlRewrite) {
                 $urlRewriteReturnArray = [
                     'id' => $urlRewrite->getEntityId(),
                     'canonical_url' => $urlRewrite->getTargetPath(),
+                    'absolute_url' => $baseUrl . $urlRewrite->getTargetPath(),
                     'type' => $this->sanitizeType($urlRewrite->getEntityType())
                 ];
                 $result = function () use ($urlRewriteReturnArray) {

--- a/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls
@@ -4,6 +4,7 @@
 type EntityUrl @doc(description: "EntityUrl is an output object containing the `id`, `canonical_url`, and `type` attributes") {
     id: Int @doc(description: "The ID assigned to the object associated with the specified url. This could be a product ID, category ID, or page ID.")
     canonical_url: String @doc(description: "The internal relative URL. If the specified  url is a redirect, the query returns the redirected URL, not the original.")
+    absolute_url: String @doc(description: "The internal absolute URL. If the specified  url is a redirect, the query returns the redirected URL, not the original.")
     type: UrlRewriteEntityTypeEnum @doc(description: "One of PRODUCT, CATEGORY, or CMS_PAGE.")
 }
 


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. urlResolver support for absolute paths #79

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Passed absolute and relative paths for CMS, Product and Category pages
2. Got always same response with the additional absolute_path field

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
