### PR TITLE
Additional checks for fragments added in category tree

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/AttributesJoiner.php
+++ b/app/code/Magento/CatalogGraphQl/Model/AttributesJoiner.php
@@ -28,6 +28,10 @@ class AttributesJoiner
 
         /** @var FieldNode $field */
         foreach ($query as $field) {
+            if ($field->kind === 'InlineFragment') {
+                continue;
+            }
+
             if (!$collection->isAttributeAdded($field->name->value)) {
                 $collection->addAttributeToSelect($field->name->value);
             }

--- a/app/code/Magento/CatalogGraphQl/Model/Category/DepthCalculator.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Category/DepthCalculator.php
@@ -26,6 +26,10 @@ class DepthCalculator
         $depth = count($selections) ? 1 : 0;
         $childrenDepth = [0];
         foreach ($selections as $node) {
+            if ($node->kind === 'InlineFragment') {
+                continue;
+            }
+
             $childrenDepth[] = $this->calculate($node);
         }
 

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/CategoryTree.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/CategoryTree.php
@@ -143,6 +143,10 @@ class CategoryTree
 
         /** @var FieldNode $node */
         foreach ($subSelection as $node) {
+            if ($node->kind === 'InlineFragment') {
+                continue;
+            }
+
             $this->joinAttributesRecursively($collection, $node);
         }
     }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryProductsVariantsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryProductsVariantsTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Catalog;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\TestFramework\ObjectManager;
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+/**
+ * Test of getting child products info of configurable product on category request
+ */
+class CategoryProductsVariantsTest extends GraphQlAbstract
+{
+    /**
+     *
+     * @magentoApiDataFixture Magento/ConfigurableProduct/_files/product_configurable.php
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function testGetSimpleProductsFromCategory()
+    {
+
+        $query
+            = <<<QUERY
+{
+  category(id: 2) {
+    id
+    name
+    products {
+      items {
+        sku
+        ... on ConfigurableProduct {
+          variants {
+            product {
+              sku
+            }
+          }
+        }
+      }
+    }
+  }
+}
+QUERY;
+
+        $response = $this->graphQlQuery($query);
+
+        /** @var ProductRepositoryInterface $productRepository */
+        $productRepository = ObjectManager::getInstance()->get(ProductRepositoryInterface::class);
+        $product = $productRepository->get('simple_10', false, null, true);
+
+        $this->assertArrayHasKey('variants', $response['category']['products']['items'][0]);
+        $this->assertCount(2, $response['category']['products']['items'][0]['variants']);
+        $this->assertSimpleProductFields($product, $response['category']['products']['items'][0]['variants'][0]);
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @param array $actualResponse
+     */
+    private function assertSimpleProductFields($product, $actualResponse)
+    {
+        $assertionMap = [
+            [
+                'response_field' => 'product', 'expected_value' => [
+                    "sku" => $product->getSku()
+                ]
+            ],
+        ];
+
+        $this->assertResponseFields($actualResponse, $assertionMap);
+    }
+
+    /**
+     * @param array $actualResponse
+     * @param array $assertionMap
+     */
+    private function assertResponseFields($actualResponse, $assertionMap)
+    {
+        foreach ($assertionMap as $key => $assertionData) {
+            $expectedValue = isset($assertionData['expected_value'])
+                ? $assertionData['expected_value']
+                : $assertionData;
+            $responseField = isset($assertionData['response_field']) ? $assertionData['response_field'] : $key;
+            self::assertNotNull(
+                $expectedValue,
+                "Value of '{$responseField}' field must not be NULL"
+            );
+            self::assertEquals(
+                $expectedValue,
+                $actualResponse[$responseField],
+                "Value of '{$responseField}' field in response does not match expected value: "
+                . var_export($expectedValue, true)
+            );
+        }
+    }
+}


### PR DESCRIPTION
### Description
For category products request on an attempt to add a fragment for checking an implementation (product type) the system throws the fatal error. The example of request:

```
{
  category(id: 14) {
    id
    name
    products {
      items {
        sku
        ... on ConfigurableProduct {
          variants {
            product {
              sku
            }
          }
        }
      }
    }
  }
}
```

The fix removes the `InlineFragment` nodes from category tree processing.

### Fixed Issues (if relevant)
https://github.com/magento/graphql-ce/issues/85

### Manual testing scenarios
- Create a configurable product with child products
- Assign the configurable product to a category with some [category_id]
- Execute the following request:

```
{
  category(id: category_id) {
    id
    name
    products {
      items {
        sku
        ... on ConfigurableProduct {
          variants {
            product {
              sku
            }
          }
        }
      }
    }
  }
}
```
- You should see the category and products info instead of the fatal error.
