### PR TITLE
Fix the category tree depth calculation bug

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/CategoryTree.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/CategoryTree.php
@@ -24,9 +24,9 @@ use Magento\CatalogGraphQl\Model\AttributesJoiner;
 class CategoryTree
 {
     /**
-     * In depth we need to calculate only children nodes, so 2 first wrapped nodes should be ignored
+     * In depth we need to calculate only children nodes, so the first wrapped node should be ignored
      */
-    const DEPTH_OFFSET = 2;
+    const DEPTH_OFFSET = 1;
 
     /**
      * @var CollectionFactory

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
@@ -63,9 +63,6 @@ class CategoryTest extends GraphQlAbstract
           children {
             level
             id
-            children {
-              id
-            }
           }
         }
       }


### PR DESCRIPTION
### Description
Fixed the issue with incorrectly calculated maximum level.

### Fixed Issues
1. magento/graphql-ce#100: Category tree depth calculation issue

### Manual testing scenarios
The result response should contain the last child item (specified on the deepest level according to the request).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
