### PR TITLE
hidden product attributes not intended for storefront

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/Attributes/Collection.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/Attributes/Collection.php
@@ -62,7 +62,8 @@ class Collection
                     ['eq' => '1'],
                     ['eq' => '1'],
                     ['eq' => '1']
-                ]);
+                ]
+            );
         }
 
         return $this->collection->load();

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/Attributes/Collection.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/Attributes/Collection.php
@@ -46,6 +46,23 @@ class Collection
             $this->collection = $this->collectionFactory->create();
             $this->collection->addFieldToFilter('is_user_defined', '1');
             $this->collection->addFieldToFilter('attribute_code', ['neq' => 'cost']);
+            $this->collection->addFieldToFilter(
+                [
+                    'is_comparable',
+                    'is_filterable',
+                    'is_filterable_in_search',
+                    'is_visible_on_front',
+                    'used_in_product_listing',
+                    'used_for_sort_by'
+                ],
+                [
+                    ['eq' => '1'],
+                    ['eq' => '1'],
+                    ['eq' => '1'],
+                    ['eq' => '1'],
+                    ['eq' => '1'],
+                    ['eq' => '1']
+                ]);
         }
 
         return $this->collection->load();


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Hidden product attributes not intended for storefront

### Fixed Issues
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/graphql-ce#25 Hide product attributes not intended for storefront

### Manual testing scenarios
1. Add custom EAV product attribute with the following properties set to NO : 'is_comparable', 'is_filterable', 'is_filterable_in_search', 'is_visible_on_front', 'used_in_product_listing', 'used_for_sort_by'
2. Refresh cache
3. Attribute should not be visible in graphql

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
