### PR TITLE
Implementation of Newsletter request to GraphQL

### DIFF
--- a/app/code/Magento/NewsletterGraphQl/Model/Resolver/SubscriptionResolver.php
+++ b/app/code/Magento/NewsletterGraphQl/Model/Resolver/SubscriptionResolver.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\NewsletterGraphQl\Model\Resolver;
+
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\Resolver\Value;
+use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Newsletter\Model\Subscriber;
+use Magento\Authorization\Model\UserContextInterface;
+
+/**
+ * UrlRewrite field resolver, used for GraphQL request processing.
+ */
+class SubscriptionResolver implements ResolverInterface
+{
+    /**
+     * @var ValueFactory
+     */
+    private $valueFactory;
+
+    /**
+     * @var Subscriber
+     */
+    private $subscriber;
+
+    /**
+     * @var UserContextInterface
+     */
+    private $userContext;
+
+    /**
+     * @param UrlFinderInterface $urlFinder
+     * @param ValueFactory $valueFactory
+     * @param CustomUrlLocatorInterface $customUrlLocator
+     */
+    public function __construct(
+        ValueFactory $valueFactory,
+        Subscriber $subscriber,
+        UserContextInterface $userContext
+    ) {
+        $this->valueFactory = $valueFactory;
+        $this->subscriber = $subscriber;
+        $this->userContext = $userContext;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) : Value {
+
+        $customerId = $this->userContext->getUserId();
+
+        $subscriberInfo = ['is_subscribed' => false];
+        if ($customerId) {
+            $subscriber = $this->subscriber->loadByCustomerId($customerId);
+            $subscriberInfo = ['is_subscribed' => $subscriber->isSubscribed()];
+        }
+        $result = function () use ($subscriberInfo) {
+            return $subscriberInfo;
+        };
+
+        return $this->valueFactory->create($result);
+    }
+
+}

--- a/app/code/Magento/NewsletterGraphQl/Model/Resolver/SubscriptionResolver.php
+++ b/app/code/Magento/NewsletterGraphQl/Model/Resolver/SubscriptionResolver.php
@@ -16,7 +16,7 @@ use Magento\Newsletter\Model\Subscriber;
 use Magento\Authorization\Model\UserContextInterface;
 
 /**
- * UrlRewrite field resolver, used for GraphQL request processing.
+ * Customer Newsletter Subscription field resolver, used for GraphQL request processing.
  */
 class SubscriptionResolver implements ResolverInterface
 {
@@ -36,9 +36,9 @@ class SubscriptionResolver implements ResolverInterface
     private $userContext;
 
     /**
-     * @param UrlFinderInterface $urlFinder
      * @param ValueFactory $valueFactory
-     * @param CustomUrlLocatorInterface $customUrlLocator
+     * @param Subscriber $subscriber
+     * @param UserContextInterface $userContext
      */
     public function __construct(
         ValueFactory $valueFactory,

--- a/app/code/Magento/NewsletterGraphQl/README.md
+++ b/app/code/Magento/NewsletterGraphQl/README.md
@@ -1,0 +1,3 @@
+# NewsletterGraphQl
+
+**NewsletterGraphQl** provides type information for the GraphQl module to receive Newsletter information

--- a/app/code/Magento/NewsletterGraphQl/composer.json
+++ b/app/code/Magento/NewsletterGraphQl/composer.json
@@ -1,0 +1,25 @@
+{
+  "name": "magento/module-newsletter-graph-ql",
+  "description": "N/A",
+  "type": "magento2-module",
+  "require": {
+    "php": "~7.1.3||~7.2.0",
+    "magento/framework": "*",
+    "magento/module-customer": "*"
+  },
+  "suggest": {
+    "magento/module-graph-ql": "*"
+  },
+  "license": [
+    "OSL-3.0",
+    "AFL-3.0"
+  ],
+  "autoload": {
+    "files": [
+      "registration.php"
+    ],
+    "psr-4": {
+      "Magento\\NewsletterGraphQl\\": ""
+    }
+  }
+}

--- a/app/code/Magento/NewsletterGraphQl/etc/module.xml
+++ b/app/code/Magento/NewsletterGraphQl/etc/module.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Magento_NewsletterGraphQl">
+        <sequence>
+            <module name="Magento_GraphQl"/>
+        </sequence>
+    </module>
+</config>

--- a/app/code/Magento/NewsletterGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/NewsletterGraphQl/etc/schema.graphqls
@@ -4,5 +4,5 @@ type Query {
 }
 
 type Subscription @doc(description: "Customer Subscription object") {
-    is_subscribed: String @doc(description: "Return if logged-in customer subscribed to Newsletter")
+    is_subscribed: Boolean @doc(description: "Return if logged-in customer subscribed to Newsletter")
 }

--- a/app/code/Magento/NewsletterGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/NewsletterGraphQl/etc/schema.graphqls
@@ -1,0 +1,8 @@
+type Query {
+    subscription : Subscription
+     @resolver(class: "Magento\\NewsletterGraphQl\\Model\\Resolver\\SubscriptionResolver") @doc(description: "The newsletter subscriptions query searches for customer subscription")
+}
+
+type Subscription @doc(description: "Customer Subscription object") {
+    is_subscribed: String @doc(description: "Return if logged-in customer subscribed to Newsletter")
+}

--- a/app/code/Magento/NewsletterGraphQl/registration.php
+++ b/app/code/Magento/NewsletterGraphQl/registration.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_NewsletterGraphQl', __DIR__);


### PR DESCRIPTION
Original Issue: 

https://github.com/magento/graphql-ce/issues/52

PR will add functionality to pull Subscriber status from Magento. 
User have to be logged in.


### Description
Call example:

`{
  subscription{
    is_subscribed
  }
}`

#### Return:

`{
  "data": {
    "subscription": {
      "is_subscribed": true
    }
  }
}`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
