### PR TITLE
Allow changing logged in customers password with Graphql mutation

### DIFF
--- a/app/code/Magento/CustomerGraphQl/Model/Resolver/Customer/Account/ChangePassword.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Resolver/Customer/Account/ChangePassword.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CustomerGraphQl\Model\Resolver\Customer\Account;
+
+use Magento\Authorization\Model\UserContextInterface;
+use Magento\Customer\Api\AccountManagementInterface;
+use Magento\Customer\Model\Customer;
+use Magento\CustomerGraphQl\Model\Resolver\Customer\CustomerDataProvider;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
+use Magento\Framework\GraphQl\Query\Resolver\Value;
+use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+/**
+ * {@inheritdoc}
+ */
+class ChangePassword implements ResolverInterface
+{
+    /**
+     * @var UserContextInterface
+     */
+    private $userContext;
+
+    /**
+     * @var AccountManagementInterface
+     */
+    private $accountManagement;
+
+    /**
+     * @var CustomerDataProvider
+     */
+    private $customerResolver;
+
+    /**
+     * @var ValueFactory
+     */
+    private $valueFactory;
+
+    /**
+     * @param UserContextInterface $userContext
+     * @param AccountManagementInterface $accountManagement
+     * @param CustomerDataProvider $customerResolver
+     * @param ValueFactory $valueFactory
+     */
+    public function __construct(
+        UserContextInterface $userContext,
+        AccountManagementInterface $accountManagement,
+        CustomerDataProvider $customerResolver,
+        ValueFactory $valueFactory
+    ) {
+        $this->userContext = $userContext;
+        $this->accountManagement = $accountManagement;
+        $this->customerResolver = $customerResolver;
+        $this->valueFactory = $valueFactory;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ): Value {
+        $customerId = (int) $this->userContext->getUserId();
+
+        if ($customerId === 0) {
+            throw new GraphQlAuthorizationException(
+                __(
+                    'Current customer does not have access to the resource "%1"',
+                    [Customer::ENTITY]
+                )
+            );
+        }
+
+        $this->accountManagement->changePasswordById($customerId, $args['currentPassword'], $args['newPassword']);
+        $data = $this->customerResolver->getCustomerById($customerId);
+        $result = function () use ($data) {
+            return !empty($data) ? $data : [];
+        };
+
+        return $this->valueFactory->create($result);
+    }
+}

--- a/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
@@ -5,6 +5,10 @@ type Query {
     customer: Customer @resolver(class: "Magento\\CustomerGraphQl\\Model\\Resolver\\Customer") @doc(description: "The customer query returns information about a customer account")
 }
 
+type Mutation {
+    changePassword(currentPassword: String!, newPassword: String!): Customer @resolver(class: "\\Magento\\CustomerGraphQl\\Model\\Resolver\\Customer\\Account\\ChangePassword") @doc(description:"Changes password for logged in customer")
+}
+
 type Customer @doc(description: "Customer defines the customer name and address and other details") {
     created_at: String @doc(description: "Timestamp indicating when the account was created")
     group_id: Int @doc(description: "The group assigned to the user. Default values are 0 (Not logged in), 1 (General), 2 (Wholesale), and 3 (Retailer)")

--- a/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
@@ -6,7 +6,7 @@ type Query {
 }
 
 type Mutation {
-    changePassword(currentPassword: String!, newPassword: String!): Customer @resolver(class: "\\Magento\\CustomerGraphQl\\Model\\Resolver\\Customer\\Account\\ChangePassword") @doc(description:"Changes password for logged in customer")
+    changeCustomerPassword(currentPassword: String!, newPassword: String!): Customer @resolver(class: "\\Magento\\CustomerGraphQl\\Model\\Resolver\\Customer\\Account\\ChangePassword") @doc(description:"Changes password for logged in customer")
 }
 
 type Customer @doc(description: "Customer defines the customer name and address and other details") {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CustomerChangePasswordTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CustomerChangePasswordTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Customer;
+
+use Magento\Customer\Api\AccountManagementInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Integration\Api\CustomerTokenServiceInterface;
+use Magento\TestFramework\ObjectManager;
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+class CustomerChangePasswordTest extends GraphQlAbstract
+{
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var AccountManagementInterface
+     */
+    private $accountManagement;
+
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     */
+    public function testCustomerChangeValidPassword()
+    {
+        $customerEmail = 'customer@example.com';
+        $oldCustomerPassword = 'password';
+        $newCustomerPassword = 'anotherPassword1';
+
+        $query = <<<QUERY
+mutation {
+  changePassword(
+    currentPassword: "$oldCustomerPassword",
+    newPassword: "$newCustomerPassword"
+  ) {
+    id
+    email
+    firstname
+    lastname
+  }
+}
+QUERY;
+
+        /** @var CustomerTokenServiceInterface $customerTokenService */
+        $customerTokenService = $this->objectManager->create(CustomerTokenServiceInterface::class);
+        $customerToken = $customerTokenService->createCustomerAccessToken($customerEmail, $oldCustomerPassword);
+        $headerMap = ['Authorization' => 'Bearer ' . $customerToken];
+        $response = $this->graphQlQuery($query, [], '', $headerMap);
+        $this->assertEquals($customerEmail, $response['changePassword']['email']);
+
+        try {
+            // registry contains the old password hash so needs to be reset
+            $this->objectManager->get(\Magento\Customer\Model\CustomerRegistry::class)
+                ->removeByEmail($customerEmail);
+            $this->accountManagement->authenticate($customerEmail, $newCustomerPassword);
+        } catch (LocalizedException $e) {
+            $this->fail('Password was not changed: ' . $e->getMessage());
+        }
+    }
+
+    public function testGuestUserCannotChangePassword()
+    {
+        $query = <<<QUERY
+mutation {
+  changePassword(
+    currentPassword: "currentpassword",
+    newPassword: "newpassword"
+  ) {
+    id
+    email
+    firstname
+    lastname
+  }
+}
+QUERY;
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('GraphQL response contains errors: Current customer' . ' ' .
+                                     'does not have access to the resource "customer"');
+        $this->graphQlQuery($query);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     */
+    public function testChangeWeakPassword()
+    {
+        $customerEmail = 'customer@example.com';
+        $oldCustomerPassword = 'password';
+        $newCustomerPassword = 'weakpass';
+
+        $query = <<<QUERY
+mutation {
+  changePassword(
+    currentPassword: "$oldCustomerPassword",
+    newPassword: "$newCustomerPassword"
+  ) {
+    id
+    email
+    firstname
+    lastname
+  }
+}
+QUERY;
+
+        /** @var CustomerTokenServiceInterface $customerTokenService */
+        $customerTokenService = $this->objectManager->create(CustomerTokenServiceInterface::class);
+        $customerToken = $customerTokenService->createCustomerAccessToken($customerEmail, $oldCustomerPassword);
+        $headerMap = ['Authorization' => 'Bearer ' . $customerToken];
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageRegExp('/Minimum of different classes of characters in password is.*/');
+
+        $this->graphQlQuery($query, [], '', $headerMap);
+    }
+
+    protected function setUp()
+    {
+        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->accountManagement = $this->objectManager->get(AccountManagementInterface::class);
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added a resolver which updates customer password. In response returns _Customer_ object (not sure whether this is necessary).

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/graphql-ce#54 : [Mutations] My Account: Change Password 

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a new user account from store front-end or admin
2. Acquire authorization with store (example uses session cookie)
3.  Execute a graphql query like:
`
curl -XPOST -H "Content-Type: application/json" -b PHPSESSID=d4d1cbf0ad346103fffc1b71d8059bc7 \
  -d '{"query": "mutation {changePassword(currentPassword: \"password\", newPassword: \"newPassword123\") {id, email, firstname, lastname}}","variables": [],"operationName": null}' \
  http://magento23.local/graphql
`
4. Ensure response has no errors and contain requested customer data

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
