### PR TITLE
Test coverage for CMS page #151

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Cms/CmsPageTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Cms/CmsPageTest.php
@@ -11,7 +11,6 @@ use Magento\Cms\Model\GetPageByIdentifier;
 use Magento\TestFramework\ObjectManager;
 use Magento\TestFramework\TestCase\GraphQlAbstract;
 
-
 class CmsPageTest extends GraphQlAbstract
 {
     /**
@@ -101,7 +100,6 @@ QUERY;
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('The CMS page with the "0" ID doesn\'t exist.');
         $this->graphQlQuery($query);
-
     }
 
     /**
@@ -132,5 +130,4 @@ QUERY;
         $this->expectExceptionMessage('No such entity.');
         $this->graphQlQuery($query);
     }
-
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Cms/CmsPageTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Cms/CmsPageTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Cms;
+
+use Magento\Cms\Model\GetPageByIdentifier;
+use Magento\TestFramework\ObjectManager;
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+
+class CmsPageTest extends GraphQlAbstract
+{
+    /**
+     * Verify the fields of CMS Page selected by page_id
+     *
+     * @magentoApiDataFixture Magento/Cms/_files/pages.php
+     */
+    public function testGetCmsPageById()
+    {
+        $cmsPage = ObjectManager::getInstance()->get(GetPageByIdentifier::class)->execute('page100', 0);
+        $pageId = $cmsPage->getPageId();
+        $cmsPageData = $cmsPage->getData();
+        $query =
+            <<<QUERY
+{
+  cmsPage(id: $pageId) {
+    url_key
+    title
+    content
+    content_heading
+    page_layout
+    meta_title
+    meta_description
+    meta_keywords
+  }
+}
+QUERY;
+
+        $response = $this->graphQlQuery($query);
+        $this->assertEquals($cmsPageData['identifier'], $response['cmsPage']['url_key']);
+        $this->assertEquals($cmsPageData['title'], $response['cmsPage']['title']);
+        $this->assertEquals($cmsPageData['content'], $response['cmsPage']['content']);
+        $this->assertEquals($cmsPageData['content_heading'], $response['cmsPage']['content_heading']);
+        $this->assertEquals($cmsPageData['page_layout'], $response['cmsPage']['page_layout']);
+        $this->assertEquals($cmsPageData['meta_title'], $response['cmsPage']['meta_title']);
+        $this->assertEquals($cmsPageData['meta_description'], $response['cmsPage']['meta_description']);
+        $this->assertEquals($cmsPageData['meta_keywords'], $response['cmsPage']['meta_keywords']);
+    }
+
+    /**
+     * Verify the message when page_id is not specified.
+     */
+    public function testGetCmsPageWithoutId()
+    {
+        $query =
+            <<<QUERY
+{
+  cmsPage {
+    url_key
+    title
+    content
+    content_heading
+    page_layout
+    meta_title
+    meta_description
+    meta_keywords
+  }
+}
+QUERY;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Page id should be specified');
+        $this->graphQlQuery($query);
+    }
+
+    /**
+     * Verify the message when page_id does not exist.
+     */
+    public function testGetCmsPageByNonExistentId()
+    {
+        $query =
+            <<<QUERY
+{
+  cmsPage(id: 0) {
+    url_key
+    title
+    content
+    content_heading
+    page_layout
+    meta_title
+    meta_description
+    meta_keywords
+  }
+}
+QUERY;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The CMS page with the "0" ID doesn\'t exist.');
+        $this->graphQlQuery($query);
+
+    }
+
+    /**
+     * Verify the message when CMS Page selected by page_id is disabled
+     *
+     * @magentoApiDataFixture Magento/Cms/_files/noroute.php
+     */
+    public function testGetDisabledCmsPageById()
+    {
+        $cmsPageId = ObjectManager::getInstance()->get(GetPageByIdentifier::class)->execute('no-route', 0)->getPageId();
+        $query =
+            <<<QUERY
+{
+  cmsPage(id: $cmsPageId) {
+    url_key
+    title
+    content
+    content_heading
+    page_layout
+    meta_title
+    meta_description
+    meta_keywords
+  }
+}
+QUERY;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No such entity.');
+        $this->graphQlQuery($query);
+    }
+
+}


### PR DESCRIPTION
### Description
This test performs these checks:
- check that all fields are present in the response;
- check 'Page id should be specified' exception;
- check 'The CMS page with the "0" ID doesn\'t exist.' exception;
- check 'No such entity.' exception

### Fixed Issues (if relevant)
1. magento/graphql-ce#151: Test coverage for CMS page/block

### Manual testing scenarios
1. Using ChromeiQL, it's possible to send the following query:

```
  cmsPage(id: 1) {
    url_key
    title
    content
    content_heading
    page_layout
    meta_title
    meta_description
    meta_keywords
  }
}
```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
