### PR TITLE
Test coverage for added breadcrumbs support #158

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/BreadcrumbsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/BreadcrumbsTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Catalog;
+
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory;
+use Magento\Framework\App\ObjectManager;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+/**
+ * Covers breadcrumbs support by GraphQl
+ */
+class BreadcrumbsTest extends GraphQlAbstract
+{
+    /**
+     * Verify the fields of CMS Block selected by identifiers.
+     *
+     * @magentoApiDataFixture Magento/Catalog/_files/category_tree.php
+     * @return void
+     */
+    public function testGetBreadcrumbs(): void
+    {
+        $categoryCollection = ObjectManager::getInstance()->get(CollectionFactory::class)->create();
+        $categoryCollection->addAttributeToFilter('name', ['eq' => 'Category 1.1.1']);
+        $selectedCategoryId = (int)$categoryCollection->getFirstItem()->getId();
+        $query =
+            <<<QUERY
+{
+  category(id: $selectedCategoryId) {
+    name
+    breadcrumbs {
+      category_id
+      category_name
+      category_level
+      category_url_key
+    }
+  }
+}
+QUERY;
+
+        $response = $this->graphQlQuery($query);
+        $this->assertArrayHasKey('category', $response);
+        $this->assertArrayHasKey('breadcrumbs', $response['category']);
+        $this->assertBaseFields($selectedCategoryId, $response);
+    }
+
+    /**
+     * Verify the fields of CMS Block selected by identifiers.
+     *
+     * @magentoApiDataFixture Magento/Catalog/_files/category_tree.php
+     * @return void
+     */
+    public function testGetBreadcrumbsForNonExistingCategory(): void
+    {
+        $query =
+            <<<QUERY
+{
+  category(id: 0) {
+    name
+    breadcrumbs {
+      category_id
+      category_name
+      category_level
+      category_url_key
+    }
+  }
+}
+QUERY;
+
+        $response = $this->graphQlQuery($query);
+        $this->assertArrayHasKey('category', $response);
+        $this->assertNull(
+            $response['category'],
+            'Value of "category" field must be NULL if requested category doesn\'t exist'
+        );
+        $this->assertCount(
+            1,
+            $response,
+            'There should be only "category" field if requested category doesn\'t exist '
+        );
+    }
+
+    /**
+     * Asserts the equality of the response fields to the fields given in assertion map.
+     * Assert that values of the fields are different from NULL
+     *
+     * @param array $actualResponse
+     * @param array $assertionMap
+     * @return void
+     */
+    private function assertResponseFields(array $actualResponse, array $assertionMap): void
+    {
+        foreach ($assertionMap as $key => $assertionData) {
+            $expectedValue = isset($assertionData['expected_value'])
+                ? $assertionData['expected_value']
+                : $assertionData;
+            $responseField = isset($assertionData['response_field']) ? $assertionData['response_field'] : $key;
+            $this->assertNotNull(
+                $expectedValue,
+                "Value of '{$responseField}' field must not be NULL"
+            );
+            $this->assertEquals(
+                $expectedValue[$key],
+                $actualResponse[$responseField],
+                "Value of '{$responseField}' field in response does not match expected value: "
+                . var_export($expectedValue, true)
+            );
+        }
+    }
+
+    /**
+     * Get breadcrumbs for given category.
+     *
+     * @param Category $category
+     * @return array
+     */
+    private function getBreadcrumbs(Category $category): array
+    {
+        $breadcrumbs = [];
+        $rootId = Bootstrap::getObjectManager()->get(StoreManagerInterface::class)
+            ->getStore()
+            ->getRootCategoryId();
+        foreach ($category->getParentCategories() as $parentCategory) {
+            if ($parentCategory->getId() !== $rootId) {
+                $breadcrumbs[] = [
+                    'category_id' => $parentCategory->getId(),
+                    'category_name' => $parentCategory->getName(),
+                    'category_level' => $parentCategory->getLevel(),
+                    'category_url_key' => $parentCategory->getUrlKey(),
+                ];
+            }
+        }
+
+        return $breadcrumbs;
+    }
+
+    /**
+     * Asserts base fields
+     *
+     * @param int $categoryId
+     * @param array $actualResponse
+     * @return void
+     */
+    private function assertBaseFields(int $categoryId, array $actualResponse): void
+    {
+        $category = Bootstrap::getObjectManager()->create(Category::class)->load($categoryId);
+        $assertionMap = [
+            [
+                'response_field' => 'category',
+                'expected_value' =>
+                    [
+                        [
+                            'name'        => $category->getName(),
+                            'breadcrumbs' => $this->getBreadcrumbs($category->getParentCategory()),
+                        ],
+
+                    ],
+            ],
+        ];
+
+        /**
+         * @param array $actualResponse
+         * @param array $assertionMap ['response_field_name' => 'response_field_value', ...]
+         *                         OR [['response_field' => $field, 'expected_value' => $value], ...]
+         */
+        $this->assertResponseFields($actualResponse, $assertionMap);
+    }
+}


### PR DESCRIPTION
### Description
This test performs these checks:
- check that all fields are present in the response;
- check that "category" is the only field of the response and it is equal to NULL when the requested category doesn't exist.

### Fixed Issues (if relevant)
1. magento/graphql-ce#158: Test coverage for added breadcrumbs support

### Manual testing scenarios
Precondition: use the console
```shell
#!/bin/bash 

endpoint="http://YOUR_BASE_WEB_URL/rest"
username="YOUR USERNAME"
password="YOUR PASSWORD"
admin_token=$(curl -X POST "$endpoint/V1/integration/admin/token" \
 --header "Content-Type: application/json" \
 -d '{"username":"'"$username"'","password":"'"$password"'"}') && echo "$admin_token" && admin_token=$(curl -X POST "$endpoint/V1/integration/admin/token" \
 --header "Content-Type: application/json" \
 -d '{"username":"'"$username"'","password":"'"$password"'"}') && echo "$admin_token" && admin_token=$(echo "$admin_token" | tr -d '"')
id=1
for i in {1..3}; do
        id1=$(($id+$i))
        id2=$(($id1+1))
        
        curl -X POST "$endpoint/V1/categories" \
        -H "Content-Type: application/json" \
        -H "Authorization: Bearer $admin_token" \
        -d '{"category":{"parent_id": "'"$id1"'","name":"'"Category $id2"'","is_active":true,"include_in_menu":true,"custom_attributes":[{"attribute_code":"is_anchor","value":"1"},{"attribute_code":"url_key","value":"'"category-$id2"'"},{"attribute_code":"url_path","value":"'"category-$id2"'"}]}}'
        
done
```

1. Using ChromeiQL, it's possible to send the following query:

```
{
  category(id: 5) {
    name
    breadcrumbs {
      category_id
      category_name
      category_level
      category_url_key
    }
  }
}
```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
