### PR TITLE
GraphQL-167: added support for @magentoApiConfigFixture

### DIFF
--- a/dev/tests/api-functional/framework/Magento/TestFramework/Annotation/ApiConfigFixture.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/Annotation/ApiConfigFixture.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\TestFramework\Annotation;
+
+/**
+ * Processor for magentoApiConfigFixture annotation
+ */
+class ApiConfigFixture extends \Magento\TestFramework\Annotation\ConfigFixture
+{
+    /**
+     * @var string
+     */
+    protected $annotation = 'magentoApiConfigFixture';
+
+    /**
+     * Reassign configuration data whenever application is reset
+     */
+    public function initStoreAfter()
+    {
+    }
+}

--- a/dev/tests/api-functional/framework/Magento/TestFramework/App/MutableScopeConfig.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/App/MutableScopeConfig.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Application configuration object. Used to access configuration when application is installed.
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\TestFramework\App;
+
+use Magento\Framework\App\Config\MutableScopeConfigInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\TestFramework\ObjectManager;
+
+/**
+ * @inheritdoc
+ */
+class MutableScopeConfig implements MutableScopeConfigInterface
+{
+    /**
+     * @var Config
+     */
+    private $testAppConfig;
+
+    /**
+     * @inheritdoc
+     */
+    public function isSetFlag($path, $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, $scopeCode = null)
+    {
+        return $this->getTestAppConfig()->isSetFlag($path, $scopeType, $scopeCode);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getValue($path, $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, $scopeCode = null)
+    {
+        return $this->getTestAppConfig()->getValue($path, $scopeType, $scopeCode);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setValue(
+        $path,
+        $value,
+        $scopeType = \Magento\Framework\App\Config\ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
+        $scopeCode = null
+    ) {
+        $this->persistConfig($path, $value, $scopeType, $scopeCode);
+        return $this->getTestAppConfig()->setValue($path, $value, $scopeType, $scopeCode);
+    }
+
+    /**
+     * Clean app config cache
+     *
+     * @param string|null $type
+     * @return void
+     */
+    public function clean()
+    {
+        $this->getTestAppConfig()->clean();
+    }
+
+    /**
+     * Retrieve test app config instance
+     *
+     * @return \Magento\TestFramework\App\Config
+     */
+    private function getTestAppConfig()
+    {
+        if (!$this->testAppConfig) {
+            $this->testAppConfig = ObjectManager::getInstance()->get(ScopeConfigInterface::class);
+        }
+
+        return $this->testAppConfig;
+    }
+
+    /**
+     * Persist config in database
+     *
+     * @param string $path
+     * @param string $value
+     * @param string $scopeType
+     * @param string|null $scopeCode
+     */
+    private function persistConfig($path, $value, $scopeType, $scopeCode): void
+    {
+        $pathParts = explode('/', $path);
+        $store = '';
+        if ($scopeType === \Magento\Store\Model\ScopeInterface::SCOPE_STORE) {
+            if ($scopeCode !== null) {
+                $store = ObjectManager::getInstance()
+                    ->get(\Magento\Store\Api\StoreRepositoryInterface::class)
+                    ->get($scopeCode)
+                    ->getId();
+            } else {
+                $store = ObjectManager::getInstance()
+                    ->get(\Magento\Store\Model\StoreManagerInterface::class)
+                    ->getStore()
+                    ->getId();
+            }
+        }
+        $configData = [
+            'section' => $pathParts[0],
+            'website' => '',
+            'store' => $store,
+            'groups' => [
+                $pathParts[1] => [
+                    'fields' => [
+                        $pathParts[2] => [
+                            'value' => $value
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        ObjectManager::getInstance()
+            ->get(\Magento\Config\Model\Config\Factory::class)
+            ->create(['data' => $configData])
+            ->save();
+    }
+}

--- a/dev/tests/api-functional/framework/Magento/TestFramework/Bootstrap/WebapiDocBlock.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/Bootstrap/WebapiDocBlock.php
@@ -10,7 +10,8 @@ namespace Magento\TestFramework\Bootstrap;
 class WebapiDocBlock extends \Magento\TestFramework\Bootstrap\DocBlock
 {
     /**
-     * Get list of subscribers. In addition, register <b>magentoApiDataFixture</b> annotation processing.
+     * Get list of subscribers. In addition, register magentoApiDataFixture and magentoApiConfigFixture
+     * annotation processors
      *
      * @param \Magento\TestFramework\Application $application
      * @return array
@@ -19,6 +20,7 @@ class WebapiDocBlock extends \Magento\TestFramework\Bootstrap\DocBlock
     {
         $subscribers = parent::_getSubscribers($application);
         $subscribers[] = new \Magento\TestFramework\Annotation\ApiDataFixture($this->_fixturesBaseDir);
+        $subscribers[] = new \Magento\TestFramework\Annotation\ApiConfigFixture($this->_fixturesBaseDir);
         return $subscribers;
     }
 }

--- a/dev/tests/integration/framework/Magento/TestFramework/Annotation/ConfigFixture.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Annotation/ConfigFixture.php
@@ -40,6 +40,11 @@ class ConfigFixture
     private $_storeConfigValues = [];
 
     /**
+     * @var string
+     */
+    protected $annotation = 'magentoConfigFixture';
+
+    /**
      * Retrieve configuration node value
      *
      * @param string $configPath
@@ -104,10 +109,10 @@ class ConfigFixture
     protected function _assignConfigData(\PHPUnit\Framework\TestCase $test)
     {
         $annotations = $test->getAnnotations();
-        if (!isset($annotations['method']['magentoConfigFixture'])) {
+        if (!isset($annotations['method'][$this->annotation])) {
             return;
         }
-        foreach ($annotations['method']['magentoConfigFixture'] as $configPathAndValue) {
+        foreach ($annotations['method'][$this->annotation] as $configPathAndValue) {
             if (preg_match('/^.+?(?=_store\s)/', $configPathAndValue, $matches)) {
                 /* Store-scoped config value */
                 $storeCode = $matches[0] != 'current' ? $matches[0] : null;


### PR DESCRIPTION

### Description
Added support for '@magentoConfigFixture' annotation on GraphQL API-functional tests

### Fixed Issues (if relevant)
1. magento/graphql-ce#167: Add support for '@magentoConfigFixture' annotation on GraphQL API-functional tests
