### PR TITLE
GraphQL-129: Retrieve Customer token

### DIFF
--- a/app/code/Magento/CustomerGraphQl/Model/Resolver/Customer/Account/GenerateCustomerToken.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Resolver/Customer/Account/GenerateCustomerToken.php
@@ -7,11 +7,10 @@ declare(strict_types=1);
 
 namespace Magento\CustomerGraphQl\Model\Resolver\Customer\Account;
 
-use Magento\Authorization\Model\UserContextInterface;
 use Magento\Integration\Api\CustomerTokenServiceInterface;
-use Magento\Customer\Model\Customer;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
+use Magento\Framework\Exception\AuthenticationException;
 use Magento\Framework\GraphQl\Query\Resolver\Value;
 use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
@@ -19,10 +18,6 @@ use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 
 class GenerateCustomerToken implements ResolverInterface
 {
-    /**
-     * @var UserContextInterface
-     */
-    private $userContext;
 
     /**
      * @var CustomerTokenServiceInterface
@@ -35,18 +30,15 @@ class GenerateCustomerToken implements ResolverInterface
     private $valueFactory;
 
     /**
-     * @param UserContextInterface          $userContext
      * @param CustomerTokenServiceInterface $customerTokenService
-     * @param ValueFactory                  $valueFactory
+     * @param ValueFactory $valueFactory
      */
     public function __construct(
-        UserContextInterface $userContext,
         CustomerTokenServiceInterface $customerTokenService,
         ValueFactory $valueFactory
     ) {
-        $this->userContext          = $userContext;
         $this->customerTokenService = $customerTokenService;
-        $this->valueFactory         = $valueFactory;
+        $this->valueFactory = $valueFactory;
     }
 
     /**
@@ -65,7 +57,7 @@ class GenerateCustomerToken implements ResolverInterface
                 return !empty($token) ? $token : '';
             };
             return $this->valueFactory->create($result);
-        }catch (\Magento\Framework\Exception\AuthenticationException $e){
+        } catch (AuthenticationException $e) {
             throw new GraphQlAuthorizationException(
                 __($e->getMessage())
             );

--- a/app/code/Magento/CustomerGraphQl/Model/Resolver/Customer/Account/GenerateCustomerToken.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Resolver/Customer/Account/GenerateCustomerToken.php
@@ -59,12 +59,16 @@ class GenerateCustomerToken implements ResolverInterface
         array $value = null,
         array $args = null
     ): Value {
-
-        $token = $this->customerTokenService->createCustomerAccessToken($args['email'], $args['password']);
-        //TODO: exception
-        $result = function () use ($token) {
-            return !empty($token) ? $token : '';
-        };
-        return $this->valueFactory->create($result);
+        try {
+            $token = $this->customerTokenService->createCustomerAccessToken($args['email'], $args['password']);
+            $result = function () use ($token) {
+                return !empty($token) ? $token : '';
+            };
+            return $this->valueFactory->create($result);
+        }catch (\Magento\Framework\Exception\AuthenticationException $e){
+            throw new GraphQlAuthorizationException(
+                __($e->getMessage())
+            );
+        }
     }
 }

--- a/app/code/Magento/CustomerGraphQl/Model/Resolver/Customer/Account/GenerateCustomerToken.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Resolver/Customer/Account/GenerateCustomerToken.php
@@ -16,9 +16,11 @@ use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 
+/**
+ * Customers Token resolver, used for GraphQL request processing.
+ */
 class GenerateCustomerToken implements ResolverInterface
 {
-
     /**
      * @var CustomerTokenServiceInterface
      */
@@ -54,7 +56,7 @@ class GenerateCustomerToken implements ResolverInterface
         try {
             $token = $this->customerTokenService->createCustomerAccessToken($args['email'], $args['password']);
             $result = function () use ($token) {
-                return !empty($token) ? $token : '';
+                return !empty($token) ? ['token' => $token] : '';
             };
             return $this->valueFactory->create($result);
         } catch (AuthenticationException $e) {

--- a/app/code/Magento/CustomerGraphQl/Model/Resolver/Customer/Account/GenerateCustomerToken.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Resolver/Customer/Account/GenerateCustomerToken.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CustomerGraphQl\Model\Resolver\Customer\Account;
+
+use Magento\Authorization\Model\UserContextInterface;
+use Magento\Integration\Api\CustomerTokenServiceInterface;
+use Magento\Customer\Model\Customer;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
+use Magento\Framework\GraphQl\Query\Resolver\Value;
+use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+class GenerateCustomerToken implements ResolverInterface
+{
+    /**
+     * @var UserContextInterface
+     */
+    private $userContext;
+
+    /**
+     * @var CustomerTokenServiceInterface
+     */
+    private $customerTokenService;
+
+    /**
+     * @var ValueFactory
+     */
+    private $valueFactory;
+
+    /**
+     * @param UserContextInterface          $userContext
+     * @param CustomerTokenServiceInterface $customerTokenService
+     * @param ValueFactory                  $valueFactory
+     */
+    public function __construct(
+        UserContextInterface $userContext,
+        CustomerTokenServiceInterface $customerTokenService,
+        ValueFactory $valueFactory
+    ) {
+        $this->userContext          = $userContext;
+        $this->customerTokenService = $customerTokenService;
+        $this->valueFactory         = $valueFactory;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ): Value {
+
+        $token = $this->customerTokenService->createCustomerAccessToken($args['email'], $args['password']);
+        //TODO: exception
+        $result = function () use ($token) {
+            return !empty($token) ? $token : '';
+        };
+        return $this->valueFactory->create($result);
+    }
+}

--- a/app/code/Magento/CustomerGraphQl/composer.json
+++ b/app/code/Magento/CustomerGraphQl/composer.json
@@ -6,6 +6,7 @@
     "php": "~7.1.3||~7.2.0",
     "magento/module-customer": "*",
     "magento/module-authorization": "*",
+    "magento/module-integration": "*",
     "magento/framework": "*"
   },
   "suggest": {

--- a/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
@@ -6,11 +6,7 @@ type Query {
 }
 
 type Mutation {
-    generateCustomerToken(email: String!, password: String!): GenerateCustomerTokenOutput! @resolver(class: "\\Magento\\CustomerGraphQl\\Model\\Resolver\\Customer\\Account\\GenerateCustomerToken") @doc(description:"Retrieve Customer token")
-}
-
-type GenerateCustomerTokenOutput {
-    token: String! @doc(description: "The customer token")
+    generateCustomerToken(email: String!, password: String!): String! @resolver(class: "\\Magento\\CustomerGraphQl\\Model\\Resolver\\Customer\\Account\\GenerateCustomerToken") @doc(description:"Retrieve Customer token")
 }
 
 type Customer @doc(description: "Customer defines the customer name and address and other details") {

--- a/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
@@ -6,7 +6,11 @@ type Query {
 }
 
 type Mutation {
-    generateCustomerToken(email: String!, password: String!): String! @resolver(class: "\\Magento\\CustomerGraphQl\\Model\\Resolver\\Customer\\Account\\GenerateCustomerToken") @doc(description:"Retrieve Customer token")
+    generateCustomerToken(email: String!, password: String!): CustomerToken @resolver(class: "\\Magento\\CustomerGraphQl\\Model\\Resolver\\Customer\\Account\\GenerateCustomerToken") @doc(description:"Retrieve Customer token")
+}
+
+type CustomerToken {
+    token: String @doc(description: "The new customer token")
 }
 
 type Customer @doc(description: "Customer defines the customer name and address and other details") {

--- a/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
@@ -5,6 +5,14 @@ type Query {
     customer: Customer @resolver(class: "Magento\\CustomerGraphQl\\Model\\Resolver\\Customer") @doc(description: "The customer query returns information about a customer account")
 }
 
+type Mutation {
+    generateCustomerToken(email: String!, password: String!): GenerateCustomerTokenOutput! @resolver(class: "\\Magento\\CustomerGraphQl\\Model\\Resolver\\Customer\\Account\\GenerateCustomerToken") @doc(description:"Retrieve Customer token")
+}
+
+type GenerateCustomerTokenOutput {
+    token: String! @doc(description: "The customer token")
+}
+
 type Customer @doc(description: "Customer defines the customer name and address and other details") {
     created_at: String @doc(description: "Timestamp indicating when the account was created")
     group_id: Int @doc(description: "The group assigned to the user. Default values are 0 (Not logged in), 1 (General), 2 (Wholesale), and 3 (Retailer)")

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GenerateCustomerTokenTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GenerateCustomerTokenTest.php
@@ -59,8 +59,8 @@ mutation {
 MUTATION;
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('GraphQL response contains errors: ' .
-            'The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later.');
+        $this->expectExceptionMessage('GraphQL response contains errors: The account sign-in' . ' ' .
+            'was incorrect or your account is disabled temporarily. Please wait and try again later.');
         $this->graphQlQuery($mutation);
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GenerateCustomerTokenTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GenerateCustomerTokenTest.php
@@ -8,10 +8,14 @@ declare(strict_types=1);
 namespace Magento\GraphQl\Customer;
 
 use Magento\TestFramework\TestCase\GraphQlAbstract;
+use PHPUnit\Framework\TestResult;
 
+/**
+ * Class GenerateCustomerTokenTest
+ * @package Magento\GraphQl\Customer
+ */
 class GenerateCustomerTokenTest extends GraphQlAbstract
 {
-
     /**
      * Verify customer token with valid credentials
      *
@@ -29,13 +33,15 @@ mutation {
 	generateCustomerToken(
         email: "{$userName}"
         password: "{$password}"
-    )
+    ) {
+        token
+    }
 }
 MUTATION;
 
         $response = $this->graphQlQuery($mutation);
         $this->assertArrayHasKey('generateCustomerToken', $response);
-        $this->assertInternalType('string', $response['generateCustomerToken']);
+        $this->assertInternalType('array', $response['generateCustomerToken']);
     }
 
     /**
@@ -54,7 +60,9 @@ mutation {
 	generateCustomerToken(
         email: "{$userName}"
         password: "{$password}"
-    )
+    ) {
+        token
+    }
 }
 MUTATION;
 

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GenerateCustomerTokenTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GenerateCustomerTokenTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Customer;
+
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+class GenerateCustomerTokenTest extends GraphQlAbstract
+{
+
+    /**
+     * Verify customer token with valid credentials
+     *
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    public function testGenerateCustomerValidToken()
+    {
+        $userName = 'customer@example.com';
+        $password = 'password';
+
+        $mutation
+            = <<<MUTATION
+mutation {
+	generateCustomerToken(
+        email: "{$userName}"
+        password: "{$password}"
+    )
+}
+MUTATION;
+
+        $response = $this->graphQlQuery($mutation);
+        $this->assertArrayHasKey('generateCustomerToken', $response);
+        $this->assertInternalType('string', $response['generateCustomerToken']);
+    }
+
+    /**
+     * Verify customer with invalid credentials
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    public function testGenerateCustomerTokenWithInvalidCredentials()
+    {
+        $userName = 'customer@example.com';
+        $password = 'bad-password';
+
+        $mutation
+            = <<<MUTATION
+mutation {
+	generateCustomerToken(
+        email: "{$userName}"
+        password: "{$password}"
+    )
+}
+MUTATION;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('GraphQL response contains errors: ' .
+            'The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later.');
+        $this->graphQlQuery($mutation);
+    }
+}


### PR DESCRIPTION
### Description
Create new mutation to retrive customer token by email and password

### Manual testing scenarios

1. Run the following request in GraphiQL:
```
mutation {
    generateCustomerToken(
        email: "customer@example.com"
        password: "password"
    ) {
        token
    }
}
```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
