### PR TITLE
GraphQL-80: rename canonical_url to relative_url and fix covered test

### DIFF
--- a/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite.php
+++ b/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite.php
@@ -75,7 +75,7 @@ class UrlRewrite implements ResolverInterface
         if ($urlRewrite) {
             $result = [
                 'id' => $urlRewrite->getEntityId(),
-                'canonical_url' => $urlRewrite->getTargetPath(),
+                'relative_url' => $urlRewrite->getTargetPath(),
                 'type' => $this->sanitizeType($urlRewrite->getEntityType())
             ];
         }

--- a/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls
@@ -1,14 +1,14 @@
 # Copyright © Magento, Inc. All rights reserved.
 # See COPYING.txt for license details.
 
-type EntityUrl @doc(description: "EntityUrl is an output object containing the `id`, `canonical_url`, and `type` attributes") {
+type EntityUrl @doc(description: "EntityUrl is an output object containing the `id`, `relative_url`, and `type` attributes") {
     id: Int @doc(description: "The ID assigned to the object associated with the specified url. This could be a product ID, category ID, or page ID.")
-    canonical_url: String @doc(description: "The internal relative URL. If the specified  url is a redirect, the query returns the redirected URL, not the original.")
+    relative_url: String @doc(description: "The internal relative URL. If the specified  url is a redirect, the query returns the redirected URL, not the original.")
     type: UrlRewriteEntityTypeEnum @doc(description: "One of PRODUCT, CATEGORY, or CMS_PAGE.")
 }
 
 type Query {
-    urlResolver(url: String!): EntityUrl @resolver(class: "Magento\\UrlRewriteGraphQl\\Model\\Resolver\\UrlRewrite") @doc(description: "The urlResolver query returns the canonical URL for a specified product, category or CMS page")
+    urlResolver(url: String!): EntityUrl @resolver(class: "Magento\\UrlRewriteGraphQl\\Model\\Resolver\\UrlRewrite") @doc(description: "The urlResolver query returns the relative URL for a specified product, category or CMS page")
 }
 
 enum UrlRewriteEntityTypeEnum {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/UrlRewrite/UrlResolverTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/UrlRewrite/UrlResolverTest.php
@@ -12,6 +12,9 @@ use Magento\CmsUrlRewrite\Model\CmsPageUrlRewriteGenerator;
 use Magento\TestFramework\ObjectManager;
 use Magento\TestFramework\TestCase\GraphQlAbstract;
 use Magento\UrlRewrite\Model\UrlFinderInterface;
+use Magento\Cms\Helper\Page as PageHelper;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 
 /**
  * Test the GraphQL endpoint's URLResolver query to verify canonical URL's are correctly returned.
@@ -28,7 +31,7 @@ class UrlResolverTest extends GraphQlAbstract
     }
 
     /**
-     * Tests if target_path(canonical_url) is resolved for Product entity
+     * Tests if target_path(relative_url) is resolved for Product entity
      *
      * @magentoApiDataFixture Magento/CatalogUrlRewrite/_files/product_with_category.php
      */
@@ -57,7 +60,7 @@ class UrlResolverTest extends GraphQlAbstract
   urlResolver(url:"{$urlPath}")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
@@ -65,12 +68,12 @@ QUERY;
         $response = $this->graphQlQuery($query);
         $this->assertArrayHasKey('urlResolver', $response);
         $this->assertEquals($product->getEntityId(), $response['urlResolver']['id']);
-        $this->assertEquals($targetPath, $response['urlResolver']['canonical_url']);
+        $this->assertEquals($targetPath, $response['urlResolver']['relative_url']);
         $this->assertEquals(strtoupper($expectedType), $response['urlResolver']['type']);
     }
 
     /**
-     * Tests the use case where canonical_url is provided as resolver input in the Query
+     * Tests the use case where relative_url is provided as resolver input in the Query
      *
      * @magentoApiDataFixture Magento/CatalogUrlRewrite/_files/product_with_category.php
      */
@@ -101,7 +104,7 @@ QUERY;
   urlResolver(url:"{$canonicalPath}")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
@@ -109,7 +112,7 @@ QUERY;
         $response = $this->graphQlQuery($query);
         $this->assertArrayHasKey('urlResolver', $response);
         $this->assertEquals($product->getEntityId(), $response['urlResolver']['id']);
-        $this->assertEquals($targetPath, $response['urlResolver']['canonical_url']);
+        $this->assertEquals($targetPath, $response['urlResolver']['relative_url']);
         $this->assertEquals(strtoupper($expectedType), $response['urlResolver']['type']);
     }
 
@@ -144,7 +147,7 @@ QUERY;
   urlResolver(url:"{$urlPath2}")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
@@ -152,7 +155,7 @@ QUERY;
         $response = $this->graphQlQuery($query);
         $this->assertArrayHasKey('urlResolver', $response);
         $this->assertEquals($categoryId, $response['urlResolver']['id']);
-        $this->assertEquals($targetPath, $response['urlResolver']['canonical_url']);
+        $this->assertEquals($targetPath, $response['urlResolver']['relative_url']);
         $this->assertEquals(strtoupper($expectedType), $response['urlResolver']['type']);
     }
 
@@ -180,14 +183,14 @@ QUERY;
   urlResolver(url:"{$requestPath}")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
 QUERY;
         $response = $this->graphQlQuery($query);
         $this->assertEquals($cmsPageId, $response['urlResolver']['id']);
-        $this->assertEquals($targetPath, $response['urlResolver']['canonical_url']);
+        $this->assertEquals($targetPath, $response['urlResolver']['relative_url']);
         $this->assertEquals(strtoupper(str_replace('-', '_', $expectedEntityType)), $response['urlResolver']['type']);
     }
 
@@ -223,7 +226,7 @@ QUERY;
   urlResolver(url:"{$urlPath}")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
@@ -231,7 +234,7 @@ QUERY;
         $response = $this->graphQlQuery($query);
         $this->assertArrayHasKey('urlResolver', $response);
         $this->assertEquals($product->getEntityId(), $response['urlResolver']['id']);
-        $this->assertEquals($targetPath, $response['urlResolver']['canonical_url']);
+        $this->assertEquals($targetPath, $response['urlResolver']['relative_url']);
         $this->assertEquals(strtoupper($expectedType), $response['urlResolver']['type']);
     }
 
@@ -263,7 +266,7 @@ QUERY;
   urlResolver(url:"{$urlPath}")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
@@ -304,7 +307,7 @@ QUERY;
   urlResolver(url:"/{$urlPath}")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
@@ -312,7 +315,7 @@ QUERY;
         $response = $this->graphQlQuery($query);
         $this->assertArrayHasKey('urlResolver', $response);
         $this->assertEquals($categoryId, $response['urlResolver']['id']);
-        $this->assertEquals($targetPath, $response['urlResolver']['canonical_url']);
+        $this->assertEquals($targetPath, $response['urlResolver']['relative_url']);
         $this->assertEquals(strtoupper($expectedType), $response['urlResolver']['type']);
     }
 
@@ -321,13 +324,28 @@ QUERY;
      */
     public function testResolveSlash()
     {
+        /** @var \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfigInterface */
+        $scopeConfigInterface = $this->objectManager->get(ScopeConfigInterface::class);
+        $homePageIdentifier = $scopeConfigInterface->getValue(PageHelper::XML_PATH_HOME_PAGE, ScopeInterface::SCOPE_STORE);
+
+        /** @var \Magento\Cms\Model\Page $page */
+        $page = $this->objectManager->get(\Magento\Cms\Model\Page::class);
+        $page->load($homePageIdentifier);
+        $homePageId = $page->getId();
+
+        /** @var \Magento\CmsUrlRewrite\Model\CmsPageUrlPathGenerator $urlPathGenerator */
+        $urlPathGenerator = $this->objectManager->get(\Magento\CmsUrlRewrite\Model\CmsPageUrlPathGenerator::class);
+
+        /** @param \Magento\Cms\Api\Data\PageInterface $page */
+        $targetPath = $urlPathGenerator->getCanonicalUrlPath($page);
+
         $query
             = <<<QUERY
 {
   urlResolver(url:"/")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
@@ -335,8 +353,8 @@ QUERY;
         $response = $this->graphQlQuery($query);
 
         $this->assertArrayHasKey('urlResolver', $response);
-        $this->assertEquals(2, $response['urlResolver']['id']);
-        $this->assertEquals('cms/page/view/page_id/2', $response['urlResolver']['canonical_url']);
+        $this->assertEquals($homePageId, $response['urlResolver']['id']);
+        $this->assertEquals($targetPath, $response['urlResolver']['relative_url']);
         $this->assertEquals('CMS_PAGE', $response['urlResolver']['type']);
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/UrlRewrite/UrlResolverTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/UrlRewrite/UrlResolverTest.php
@@ -326,19 +326,18 @@ QUERY;
     {
         /** @var \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfigInterface */
         $scopeConfigInterface = $this->objectManager->get(ScopeConfigInterface::class);
-        $homePageIdentifier = $scopeConfigInterface->getValue(PageHelper::XML_PATH_HOME_PAGE, ScopeInterface::SCOPE_STORE);
-
+        $homePageIdentifier = $scopeConfigInterface->getValue(
+            PageHelper::XML_PATH_HOME_PAGE,
+            ScopeInterface::SCOPE_STORE
+        );
         /** @var \Magento\Cms\Model\Page $page */
         $page = $this->objectManager->get(\Magento\Cms\Model\Page::class);
         $page->load($homePageIdentifier);
         $homePageId = $page->getId();
-
         /** @var \Magento\CmsUrlRewrite\Model\CmsPageUrlPathGenerator $urlPathGenerator */
         $urlPathGenerator = $this->objectManager->get(\Magento\CmsUrlRewrite\Model\CmsPageUrlPathGenerator::class);
-
         /** @param \Magento\Cms\Api\Data\PageInterface $page */
         $targetPath = $urlPathGenerator->getCanonicalUrlPath($page);
-
         $query
             = <<<QUERY
 {
@@ -351,7 +350,6 @@ QUERY;
 }
 QUERY;
         $response = $this->graphQlQuery($query);
-
         $this->assertArrayHasKey('urlResolver', $response);
         $this->assertEquals($homePageId, $response['urlResolver']['id']);
         $this->assertEquals($targetPath, $response['urlResolver']['relative_url']);


### PR DESCRIPTION
### Description

1. Rename canonical_url to relative_url.
2. Fix functional test.

### Manual testing scenarios

1. Run the following request in GraphiQL:
```
{
urlResolver(url:"/test-product.html") {
   id
   relative_url
   type
 }
}
```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
