### PR TITLE
GraphQL-215: Total pages field returns null in category query

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Products.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Products.php
@@ -92,7 +92,8 @@ class Products implements ResolverInterface
             'items'       => $searchResult->getProductsSearchResult(),
             'page_info'   => [
                 'page_size'    => $searchCriteria->getPageSize(),
-                'current_page' => $currentPage
+                'current_page' => $currentPage,
+                'total_pages' => $maxPages
             ]
         ];
         return $data;


### PR DESCRIPTION
### Description (*)
Added code for response in set **total_pages**.

### Fixed Issues (if relevant)
1. magento/graphql-ce#215: Total pages field returns null in category query
