### PR TITLE
Added option_id in response for product with customizable options.

### DIFF
--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -361,6 +361,7 @@ interface CustomizableOptionInterface @typeResolver(class: "Magento\\CatalogGrap
     title: String @doc(description: "The display name for this option")
     required: Boolean @doc(description: "Indicates whether the option is required")
     sort_order: Int @doc(description: "The order in which the option is displayed")
+    option_id: Int @doc(description: "Option ID")
 }
 
 interface CustomizableProductInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\\ProductInterfaceTypeResolverComposite") @doc(description: "CustomizableProductInterface contains information about customizable product options.") {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductViewTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductViewTest.php
@@ -92,6 +92,7 @@ class ProductViewTest extends GraphQlAbstract
                 title
                 required
                 sort_order
+                option_id
                 ... on CustomizableFieldOption {
                   product_sku
                   field_option: value {
@@ -343,6 +344,7 @@ QUERY;
                 title
                 required
                 sort_order
+                option_id
                 ... on CustomizableFieldOption {
                   product_sku
                   field_option: value {
@@ -763,7 +765,8 @@ QUERY;
             $assertionMap = [
                 ['response_field' => 'sort_order', 'expected_value' => $option->getSortOrder()],
                 ['response_field' => 'title', 'expected_value' => $option->getTitle()],
-                ['response_field' => 'required', 'expected_value' => $option->getIsRequire()]
+                ['response_field' => 'required', 'expected_value' => $option->getIsRequire()],
+                ['response_field' => 'option_id', 'expected_value' => $option->getOptionId()]
             ];
 
             if (!empty($option->getValues())) {
@@ -787,7 +790,7 @@ QUERY;
                         ['response_field' => 'product_sku', 'expected_value' => $option->getProductSku()],
                     ]
                 );
-                $valueKeyName = "";
+
                 if ($option->getType() === 'file') {
                     $valueKeyName = 'file_option';
                     $valueAssertionMap = [


### PR DESCRIPTION
### Description
The schema has no 'id' field.
### Fixed Issues (if relevant)
Added 'option_id' field in schema.
### Manual testing scenarios
Query:
```{
  products(filter: {sku: {eq: "simple"}}) {
    items {
      id
      attribute_set_id
      created_at
      name
      sku
      type_id
      updated_at
      ... on CustomizableProductInterface {
        options {
          title
          required
          sort_order
          option_id
        }
      }
    }
  }
}
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
