### PR TITLE
Added a separate resolver for returning category products count

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Category/Hydrator.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Category/Hydrator.php
@@ -52,7 +52,6 @@ class Hydrator
             $categoryData = $category->getData();
         } else {
             $categoryData = $this->dataObjectProcessor->buildOutputDataArray($category, CategoryInterface::class);
-            $categoryData['product_count'] = $category->getProductCount();
         }
         $categoryData['id'] = $category->getId();
         $categoryData['children'] = [];

--- a/app/code/Magento/CatalogGraphQl/Model/Category/Hydrator.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Category/Hydrator.php
@@ -56,6 +56,7 @@ class Hydrator
         $categoryData['id'] = $category->getId();
         $categoryData['children'] = [];
         $categoryData['available_sort_by'] = $category->getAvailableSortBy();
+        $categoryData['model'] = $category;
         return $this->flattener->flatten($categoryData);
     }
 }

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Products.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Products.php
@@ -65,7 +65,7 @@ class Products implements ResolverInterface
                 'eq' => $value['id']
             ]
         ];
-            $searchCriteria = $this->searchCriteriaBuilder->build($field->getName(), $args);
+        $searchCriteria = $this->searchCriteriaBuilder->build($field->getName(), $args);
         $searchCriteria->setCurrentPage($args['currentPage']);
         $searchCriteria->setPageSize($args['pageSize']);
         $searchResult = $this->filterQuery->getResult($searchCriteria, $info);

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Products.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Products.php
@@ -65,7 +65,7 @@ class Products implements ResolverInterface
                 'eq' => $value['id']
             ]
         ];
-        $searchCriteria = $this->searchCriteriaBuilder->build($field->getName(), $args);
+            $searchCriteria = $this->searchCriteriaBuilder->build($field->getName(), $args);
         $searchCriteria->setCurrentPage($args['currentPage']);
         $searchCriteria->setPageSize($args['pageSize']);
         $searchResult = $this->filterQuery->getResult($searchCriteria, $info);

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/ProductsCount.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/ProductsCount.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogGraphQl\Model\Resolver\Category;
+
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessor\StockProcessor;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+
+/**
+ * Retrieves products count for a category
+ */
+class ProductsCount implements ResolverInterface
+{
+    /**
+     * @var Visibility
+     */
+    private $catalogProductVisibility;
+
+    /**
+     * @var StockProcessor
+     */
+    private $stockProcessor;
+
+    /**
+     * @var SearchCriteriaInterface
+     */
+    private $searchCriteria;
+
+    /**
+     * @param Visibility $catalogProductVisibility
+     * @param SearchCriteriaInterface $searchCriteria
+     * @param StockProcessor $stockProcessor
+     */
+    public function __construct(
+        Visibility $catalogProductVisibility,
+        SearchCriteriaInterface $searchCriteria,
+        StockProcessor $stockProcessor
+    ) {
+        $this->catalogProductVisibility = $catalogProductVisibility;
+        $this->searchCriteria = $searchCriteria;
+        $this->stockProcessor = $stockProcessor;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (!isset($value['model'])) {
+            throw new GraphQlInputException(__('"model" value should be specified'));
+        }
+        /** @var Category $category */
+        $category = $value['model'];
+        $productsCollection = $category->getProductCollection();
+        $productsCollection->setVisibility($this->catalogProductVisibility->getVisibleInSiteIds());
+        $productsCollection = $this->stockProcessor->process($productsCollection, $this->searchCriteria, []);
+
+        return $productsCollection->getSize();
+    }
+}

--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -379,7 +379,7 @@ interface CategoryInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model
     level: Int @doc(description: "Indicates the depth of the category within the tree")
     created_at: String @doc(description: "Timestamp indicating when the category was created")
     updated_at: String @doc(description: "Timestamp indicating when the category was updated")
-    product_count: Int @doc(description: "The number of products in the category")
+    product_count: Int @doc(description: "The number of products in the category") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\ProductsCount")
     default_sort_by: String @doc(description: "The attribute to use for sorting")
     products(
         pageSize: Int = 20 @doc(description: "Specifies the maximum number of results to return at once. This attribute is optional."),

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryProductsCountTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryProductsCountTest.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Catalog;
+
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Catalog\Model\Product\Attribute\Source\Status as productStatus;
+
+/**
+ * Class CategoryProductsCountTest
+ *
+ * Test for Magento\CatalogGraphQl\Model\Resolver\Category\ProductsCount resolver
+ */
+class CategoryProductsCountTest extends GraphQlAbstract
+{
+    /**
+     * @var ProductRepositoryInterface
+     */
+    private $productRepository;
+
+    protected function setUp()
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->productRepository = $objectManager->create(ProductRepositoryInterface::class);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Catalog/_files/product_simple.php
+     */
+    public function testCategoryWithSaleableProduct()
+    {
+        $categoryId = 2;
+
+        $query = <<<QUERY
+{
+  category(id: {$categoryId}) {
+      id
+      product_count
+    }
+}
+QUERY;
+        $response = $this->graphQlQuery($query);
+
+        self::assertEquals(1, $response['category']['product_count']);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Catalog/_files/category_product.php
+     */
+    public function testCategoryWithInvisibleProduct()
+    {
+        $categoryId = 333;
+        $sku = 'simple333';
+
+        $product = $this->productRepository->get($sku);
+        $product->setVisibility(Visibility::VISIBILITY_NOT_VISIBLE);
+        $this->productRepository->save($product);
+
+        $query = <<<QUERY
+{
+  category(id: {$categoryId}) {
+      id
+      product_count
+    }
+}
+QUERY;
+        $response = $this->graphQlQuery($query);
+
+        self::assertEquals(0, $response['category']['product_count']);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Catalog/_files/product_simple_out_of_stock.php
+     */
+    public function testCategoryWithOutOfStockProductManageStockEnabled()
+    {
+        $categoryId = 2;
+
+        $query = <<<QUERY
+{
+  category(id: {$categoryId}) {
+      id
+      product_count
+    }
+}
+QUERY;
+        $response = $this->graphQlQuery($query);
+
+        self::assertEquals(0, $response['category']['product_count']);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Catalog/_files/category_product.php
+     */
+    public function testCategoryWithOutOfStockProductManageStockDisabled()
+    {
+        $categoryId = 333;
+
+        $query = <<<QUERY
+{
+  category(id: {$categoryId}) {
+      id
+      product_count
+    }
+}
+QUERY;
+        $response = $this->graphQlQuery($query);
+
+        self::assertEquals(1, $response['category']['product_count']);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Catalog/_files/category_product.php
+     */
+    public function testCategoryWithDisabledProduct()
+    {
+        $categoryId = 333;
+        $sku = 'simple333';
+
+        $product = $this->productRepository->get($sku);
+        $product->setStatus(ProductStatus::STATUS_DISABLED);
+        $this->productRepository->save($product);
+
+        $query = <<<QUERY
+{
+  category(id: {$categoryId}) {
+      id
+      product_count
+    }
+}
+QUERY;
+        $response = $this->graphQlQuery($query);
+
+        self::assertEquals(0, $response['category']['product_count']);
+    }
+}


### PR DESCRIPTION
### Description (*)
The `product_count` field of the category query now returns a value from the corresponding field of `catalog_category_entity`. Using this approach brings additional issues since the value in the database sometimes does not reflect the real products count. Moreover, if we request products of this category, the GraphQL query returns only products that are saleable (visible and in stock). So `product_count` value will show the different result if some products of the category are out of stock or not visible.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/graphql-ce/issues/214 : Incorrect returned values of product_count
2. https://github.com/magento/graphql-ce/issues/238 : Configurable Products counted but not retrieved in GraphQL (works with REST endpoint)

### Manual testing scenarios (*)
1. Add some products to a category and make some of them out of stock or not visible individually
2. Use a similar query to retrieve the category and products:

```
{
  category(id: 1158) {
    product_count
    products {
      items {
        name
      }
      total_count
    }
  }
}
```

3. The value in `product_count` field should corresponds to the total number of fetched products
4. The value in `total_count` field should equal the value in `products_count`
