### PR TITLE
Missed PHPDoc argument headers in method graphQlQuery

### DIFF
--- a/dev/tests/api-functional/framework/Magento/TestFramework/TestCase/GraphQlAbstract.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/TestCase/GraphQlAbstract.php
@@ -52,11 +52,14 @@ abstract class GraphQlAbstract extends WebapiAbstract
     }
 
     /**
+     * Compose headers
+     *
+     * @param array $headers
      * @return string[]
      */
-    private function composeHeaders($headers)
+    private function composeHeaders(array $headers): array
     {
-        $headersArray =[];
+        $headersArray = [];
         foreach ($headers as $key => $value) {
             $headersArray[] = sprintf('%s: %s', $key, $value);
         }

--- a/dev/tests/api-functional/framework/Magento/TestFramework/TestCase/GraphQlAbstract.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/TestCase/GraphQlAbstract.php
@@ -33,6 +33,7 @@ abstract class GraphQlAbstract extends WebapiAbstract
      * @param string $query
      * @param array $variables
      * @param string $operationName
+     * @param array $headers
      * @return array|int|string|float|bool GraphQL call results
      * @throws \Exception
      */


### PR DESCRIPTION
### Description (*)
Missed PHPDoc argument '$headers' in method dev/tests/api-functional/framework/Magento/TestFramework/TestCase/GraphQlAbstract::graphQlQuery
### Fixed Issues (if relevant)
Added in PHPDoc  @param array $headers

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
