### PR TITLE
Added label from store view

### DIFF
--- a/app/code/Magento/ConfigurableProductGraphQl/Model/Options/Collection.php
+++ b/app/code/Magento/ConfigurableProductGraphQl/Model/Options/Collection.php
@@ -124,6 +124,9 @@ class Collection
             $this->attributeMap[$productId][$attribute->getId()]['attribute_code']
                 = $attribute->getProductAttribute()->getAttributeCode();
             $this->attributeMap[$productId][$attribute->getId()]['values'] = $attributeData['options'];
+
+            $this->attributeMap[$productId][$attribute->getId()]['label']
+                = $attribute->getProductAttribute()->getStoreLabel();
         }
 
         return $this->attributeMap;

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Swatches/ProductViewTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Swatches/ProductViewTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Swatches;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\EntityManager\MetadataPool;
+use Magento\Swatches\Helper\Data as SwatchesHelper;
+use Magento\TestFramework\ObjectManager;
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+/**
+ * Class ProductViewTest
+ * @package Magento\GraphQl\Swatches
+ */
+class ProductViewTest extends GraphQlAbstract
+{
+    public const IMAGE = 'IMAGE';
+    public const COLOR = 'COLOR';
+    /**
+     * @var array
+     */
+    private $configurableOptions = [];
+    /**
+     * @var SwatchesHelper
+     */
+    private $swatchesHelper;
+
+    /**
+     * @inheritdoc
+     */
+    public function setUp()
+    {
+        $this->swatchesHelper = ObjectManager::getInstance()->get(SwatchesHelper::class);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Swatches/_files/configurable_products_with_swatches.php
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    public function testQuerySwatchDataFields()
+    {
+        $productSku = 'configurable';
+
+        $query
+            = <<<QUERY
+{
+  products(filter: {sku: {eq: "configurable"}}) {
+    items {
+      name
+        ... on ConfigurableProduct{
+        configurable_options{
+          id
+          label
+          values {
+            value_index
+            label
+            default_label
+            store_label
+            use_default_value
+          }
+        }
+      }
+    }
+  }
+}
+QUERY;
+        $response = $this->graphQlQuery($query);
+
+        /** @var ProductRepositoryInterface $productRepository */
+        $productRepository = ObjectManager::getInstance()->get(ProductRepositoryInterface::class);
+        $product = $productRepository->get($productSku, false, null, true);
+        /** @var MetadataPool $metadataPool */
+        $metadataPool = ObjectManager::getInstance()->get(MetadataPool::class);
+        $product->setId(
+            $product->getData($metadataPool->getMetadata(ProductInterface::class)->getLinkField())
+        );
+        $this->assertArrayHasKey('products', $response);
+        $this->assertArrayHasKey('items', $response['products']);
+        $configurableOptions = $this->getConfigurableOptions();
+
+        $this->assertBaseFields($response['products'], $configurableOptions);
+    }
+
+    /**
+     * @param $actualResponse
+     * @param $configurableOptions
+     */
+    private function assertBaseFields($actualResponse, $configurableOptions): void
+    {
+        $assertionMap =
+            [
+                'items' => [
+                    [
+                        'name' => 'Configurable Product',
+                        'configurable_options' => [
+                            [
+                                'id' => (int)$configurableOptions['id'],
+                                'label' => $configurableOptions['label'],
+                                'values' => $configurableOptions['options']
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+
+        $this->assertResponseFields($actualResponse, $assertionMap);
+    }
+
+    /**
+     * @return array
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    private function getConfigurableOptions(): array
+    {
+        if (!empty($this->configurableOptions)) {
+            return $this->configurableOptions;
+        }
+        $productSku = 'configurable';
+        /** @var ProductRepositoryInterface $productRepo */
+        $productRepo = ObjectManager::getInstance()->get(ProductRepositoryInterface::class);
+
+        $product = $productRepo->get($productSku);
+        $configurableAttributeOptions = $product->getExtensionAttributes()->getConfigurableProductOptions();
+        $configurableAttributeOptionsData = [];
+        foreach ($configurableAttributeOptions as $option) {
+            $optionData = $option->getData();
+            $configurableAttributeOptionsData['label'] = $optionData['label'];
+            $cnt = 0;
+            foreach ($optionData['options'] as $data) {
+                $configurableAttributeOptionsData['options'][$cnt]['value_index'] = (int)$data['value_index'];
+                $configurableAttributeOptionsData['options'][$cnt]['label'] = $data['label'];
+                $configurableAttributeOptionsData['options'][$cnt]['default_label'] = $data['default_label'];
+                $configurableAttributeOptionsData['options'][$cnt]['store_label'] = $data['store_label'];
+                $configurableAttributeOptionsData['options'][$cnt]['use_default_value'] = $data['use_default_value'];
+                $cnt++;
+            }
+
+            $configurableAttributeOptionsData['id'] = $option->getId();
+            $configurableAttributeOptionsData['attribute_code']
+                = $option->getProductAttribute()->getAttributeCode();
+        }
+
+        return $this->configurableOptions = $configurableAttributeOptionsData;
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Swatches/_files/configurable_products_with_swatches.php
+++ b/dev/tests/integration/testsuite/Magento/Swatches/_files/configurable_products_with_swatches.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\Product\Type;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Catalog\Setup\CategorySetup;
+use Magento\ConfigurableProduct\Helper\Product\Options\Factory;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Eav\Api\Data\AttributeOptionInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+require __DIR__ . '/swatch_attribute_color.php';
+
+/** @var ProductRepositoryInterface $productRepository */
+$productRepository = Bootstrap::getObjectManager()
+    ->get(ProductRepositoryInterface::class);
+
+/** @var $installer CategorySetup */
+$installer = Bootstrap::getObjectManager()->create(CategorySetup::class);
+
+/* Create simple products per each option value*/
+/** @var AttributeOptionInterface[] $options */
+$options = $attribute->getOptions();
+
+$attributeValues = [];
+$attributeSetId = $installer->getAttributeSetId('catalog_product', 'Default');
+$associatedProductIds = [];
+$productIds = [10, 20,30];
+array_shift($options); //remove the first option which is empty
+
+foreach ($options as $option) {
+    /** @var $product Product */
+    $product = Bootstrap::getObjectManager()->create(Product::class);
+    $productId = array_shift($productIds);
+    $product->setTypeId(Type::TYPE_SIMPLE)
+        ->setId($productId)
+        ->setAttributeSetId($attributeSetId)
+        ->setWebsiteIds([1])
+        ->setName('Configurable Option' . $option->getLabel())
+        ->setSku('simple_' . $productId)
+        ->setPrice($productId)
+        ->setColorSwatch($option->getValue())
+        ->setVisibility(Visibility::VISIBILITY_NOT_VISIBLE)
+        ->setStatus(Status::STATUS_ENABLED)
+        ->setStockData(['use_config_manage_stock' => 1, 'qty' => 100, 'is_qty_decimal' => 0, 'is_in_stock' => 1]);
+    $product = $productRepository->save($product);
+
+    $attributeValues[] = [
+        'label' => 'test',
+        'attribute_id' => $attribute->getId(),
+        'value_index' => $option->getValue(),
+    ];
+    $associatedProductIds[] = $product->getId();
+}
+
+/** @var $product Product */
+$product = Bootstrap::getObjectManager()->create(Product::class);
+/** @var Factory $optionsFactory */
+$optionsFactory = Bootstrap::getObjectManager()->create(Factory::class);
+$configurableAttributesData = [
+    [
+        'attribute_id' => $attribute->getId(),
+        'code' => $attribute->getAttributeCode(),
+        'label' => $attribute->getStoreLabel(),
+        'position' => '0',
+        'values' => $attributeValues,
+    ],
+];
+$configurableOptions = $optionsFactory->create($configurableAttributesData);
+$extensionConfigurableAttributes = $product->getExtensionAttributes();
+$extensionConfigurableAttributes->setConfigurableProductOptions($configurableOptions);
+$extensionConfigurableAttributes->setConfigurableProductLinks($associatedProductIds);
+$product->setExtensionAttributes($extensionConfigurableAttributes);
+
+$product->setTypeId(Configurable::TYPE_CODE)
+    ->setId(1)
+    ->setAttributeSetId($attributeSetId)
+    ->setWebsiteIds([1])
+    ->setName('Configurable Product')
+    ->setSku('configurable')
+    ->setVisibility(Visibility::VISIBILITY_BOTH)
+    ->setStatus(Status::STATUS_ENABLED)
+    ->setStockData(['use_config_manage_stock' => 1, 'is_in_stock' => 1]);
+$productRepository->cleanCache();
+$productRepository->save($product);

--- a/dev/tests/integration/testsuite/Magento/Swatches/_files/configurable_products_with_swatches_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Swatches/_files/configurable_products_with_swatches_rollback.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+$objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+
+/** @var \Magento\Framework\Registry $registry */
+$registry = $objectManager->get(\Magento\Framework\Registry::class);
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', true);
+
+/** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
+$productRepository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+    ->get(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+
+foreach (['simple_10', 'simple_20', 'simple_30','configurable'] as $sku) {
+    try {
+        $product = $productRepository->get($sku, true);
+
+        $stockStatus = $objectManager->create(\Magento\CatalogInventory\Model\Stock\Status::class);
+        $stockStatus->load($product->getEntityId(), 'product_id');
+        $stockStatus->delete();
+
+        $productRepository->delete($product);
+    } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+        //Product already removed
+    }
+}
+
+require __DIR__ . '/swatch_attribute_color_rollback.php';
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', false);

--- a/dev/tests/integration/testsuite/Magento/Swatches/_files/swatch_attribute_color.php
+++ b/dev/tests/integration/testsuite/Magento/Swatches/_files/swatch_attribute_color.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+use Magento\Eav\Api\Data\AttributeOptionInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+/** @var \Magento\Framework\ObjectManagerInterface $objectManager */
+$objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+$installer = Bootstrap::getObjectManager()->create(\Magento\Catalog\Setup\CategorySetup::class);
+$data = [
+    'attribute_code' => 'color_swatch',
+    'entity_type_id' => $installer->getEntityTypeId('catalog_product'),
+    'is_global' => 1,
+    'is_user_defined' => 1,
+    'frontend_input' => 'select',
+    'is_unique' => 0,
+    'is_required' => 0,
+    'is_searchable' => 1,
+    'is_visible_in_advanced_search' => 1,
+    'is_comparable' => 1,
+    'is_filterable' => 1,
+    'is_filterable_in_search' => 1,
+    'is_used_for_promo_rules' => 0,
+    'is_html_allowed_on_front' => 1,
+    'is_visible_on_front' => 1,
+    'used_in_product_listing' => 1,
+    'used_for_sort_by' => 1,
+    'frontend_label' => ['Color Swatch', 'Store Label'],
+    'backend_type' => 'int',
+    'use_product_image_for_swatch' => 0,
+    'update_product_preview_image' => 0,
+];
+$optionsPerAttribute = 3;
+
+$data['swatch_input_type'] = 'visual';
+$data['swatchvisual']['value'] = array_reduce(
+    range(1, $optionsPerAttribute),
+    function ($values, $index) use ($optionsPerAttribute) {
+        $values['option_' . $index] = '#'
+            . str_repeat(
+                dechex(255 * $index / $optionsPerAttribute),
+                3
+            );
+        return $values;
+    },
+    []
+);
+$data['optionvisual']['value'] = array_reduce(
+    range(1, $optionsPerAttribute),
+    function ($values, $index) use ($optionsPerAttribute) {
+        $values['option_' . $index] = ['option ' . $index];
+        return $values;
+    },
+    []
+);
+
+$data['options']['option'] = array_reduce(
+    range(1, $optionsPerAttribute),
+    function ($values, $index) use ($optionsPerAttribute) {
+        $values[] = [
+            'label' => 'option ' . $index,
+            'value' => 'option_' . $index,
+        ];
+        return $values;
+    },
+    []
+);
+
+$options = [];
+foreach ($data['options']['option'] as $optionData) {
+    $options[] = $objectManager->get(AttributeOptionInterface::class)
+        ->setLabel($optionData['label'])
+        ->setValue($optionData['value']);
+}
+
+$attribute = $objectManager->create(
+    \Magento\Catalog\Api\Data\ProductAttributeInterface::class,
+    ['data' => $data]
+);
+$attribute->setOptions($options);
+$attribute->save();
+
+/* Assign attribute to attribute set */
+$installer->addAttributeToGroup('catalog_product', 'Default', 'General', $attribute->getId());
+
+/** @var \Magento\Eav\Model\Config $eavConfig */
+$eavConfig = Bootstrap::getObjectManager()->get(\Magento\Eav\Model\Config::class);
+$eavConfig->clear();
+
+$attribute = $eavConfig->getAttribute('catalog_product', 'color_swatch');
+$options = $attribute->getOptions();
+
+// workaround for saved attribute
+$attribute->setDefaultValue($options[1]->getValue());
+
+$attribute->save();
+$eavConfig->clear();

--- a/dev/tests/integration/testsuite/Magento/Swatches/_files/swatch_attribute_color_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Swatches/_files/swatch_attribute_color_rollback.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+/** @var \Magento\Framework\Registry $registry */
+$registry = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Framework\Registry::class);
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', true);
+
+/** @var \Magento\Catalog\Model\ResourceModel\Eav\Attribute $attribute */
+$attribute = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+    ->create(\Magento\Catalog\Model\ResourceModel\Eav\Attribute::class);
+
+$attribute->loadByCode(4, 'color_swatch');
+
+if ($attribute->getId()) {
+    $attribute->delete();
+}
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', false);


### PR DESCRIPTION
### Description (*)
PR for issue #250 Configurable Options Label doesn't return the Store View Label
This PR added functionality to show store label in label response

### Fixed Issues (if relevant)

magento/graphql-ce#250: Configurable Options Label doesn't return the Store View Label


### Manual testing scenarios (*)
Request: Store Label "Custom Color", Default label "Color"
```
{
  products(filter: { sku: { eq: "Test Configurable" } }) {
    items {
      name
      ... on ConfigurableProduct {
        configurable_options {
          attribute_code
          id
          label
        }
      }
    }
  }
}
```
Response:
```
{
  "data": {
    "products": {
      "items": [
        {
          "name": "Test Configurable",
          "configurable_options": [
            {
              "attribute_code": "color",
              "id": 35,
              "label": "Custom Color"
            }
          ]
        }
      ]
    }
  }
}
```

Response with empty Store Label
```
{
  "data": {
    "products": {
      "items": [
        {
          "name": "Test Configurable",
          "configurable_options": [
            {
              "attribute_code": "color",
              "id": 35,
              "label": "Color"
            }
          ]
        }
      ]
    }
  }
}
```
Also tested with different store and with branch 2.3-develop.
Api-functional test included.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
