### PR TITLE
[200] Product compare graphQl functionality

### DIFF
--- a/app/code/Magento/ProductCompareGraphQl/Model/DataProvider/Visitor.php
+++ b/app/code/Magento/ProductCompareGraphQl/Model/DataProvider/Visitor.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ProductCompareGraphQl\Model\DataProvider;
+
+use Magento\Framework\Session\SessionManagerInterface;
+use Magento\Catalog\Model\Product\Compare\Item;
+
+class Visitor
+{
+    const VISITOR_ID_KEY = 'visitor_id';
+    const CUSTOMER_ID_KEY = 'customer_id';
+
+    /**
+     * @var SessionManagerInterface
+     */
+    private $sessionManager;
+
+    /**
+     * @param SessionManagerInterface $sessionManager
+     */
+    public function __construct(SessionManagerInterface $sessionManager)
+    {
+        $this->sessionManager = $sessionManager;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getVisitorId()
+    {
+        return $this->getVisitorData(self::VISITOR_ID_KEY);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCustomerId()
+    {
+        return $this->getVisitorData(self::CUSTOMER_ID_KEY);
+    }
+
+    /**
+     * @param Item $item
+     *
+     * @return Item
+     */
+    public function addUserToItem(Item $item)
+    {
+        $customerId = $this->getCustomerId();
+        if (!empty($customerId)) {
+            $item->setCustomerId((int)$customerId);
+        } else {
+            $item->setVisitorId((int)$this->getVisitorId());
+        }
+        return $item;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return string|null
+     */
+    private function getVisitorData(string $key)
+    {
+        $data = $this->sessionManager->getVisitorData();
+        return $data[$key] ?? null;
+    }
+}

--- a/app/code/Magento/ProductCompareGraphQl/Model/Resolver/AddProductToCompare.php
+++ b/app/code/Magento/ProductCompareGraphQl/Model/Resolver/AddProductToCompare.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ProductCompareGraphQl\Model\Resolver;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\ProductCompareGraphQl\Model\DataProvider\Visitor;
+use Magento\Catalog\Model\Product\Compare\ItemFactory;
+
+/**
+ * Resolver for Add Product to Compare List mutation
+ */
+class AddProductToCompare implements ResolverInterface
+{
+    /**
+     * @var ItemFactory
+     */
+    private $compareItemFactory;
+
+    /**
+     * @var Visitor
+     */
+    private $visitorDataProvider;
+
+    /**
+     * @param Visitor     $visitorDataProvider
+     * @param ItemFactory $compareItemFactory
+     */
+    public function __construct(
+        Visitor $visitorDataProvider,
+        ItemFactory $compareItemFactory
+    ) {
+        $this->visitorDataProvider = $visitorDataProvider;
+        $this->compareItemFactory = $compareItemFactory;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($args['input']) || !is_array($args['input']) || empty($args['input'])) {
+            throw new GraphQlInputException(__('"input" value should be specified'));
+        }
+        $result = ['result' => false, "compareProducts" => []];
+        if (!empty($args['input']['ids']) && is_array($args['input']['ids'])) {
+            foreach ($args['input']['ids'] as $id) {
+                $item = $this->compareItemFactory->create();
+                $item = $this->visitorDataProvider->addUserToItem($item);
+                $item->loadByProduct($id);
+                if (!$item->getId()) {
+                    $item->addProductData((int)$id);
+                    $item->save();
+                }
+            }
+            $result = ['result' => true, "compareProducts" => []];
+        }
+        return $result;
+    }
+}

--- a/app/code/Magento/ProductCompareGraphQl/Model/Resolver/CompareProducts.php
+++ b/app/code/Magento/ProductCompareGraphQl/Model/Resolver/CompareProducts.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ProductCompareGraphQl\Model\Resolver;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Catalog\Model\ResourceModel\Product\Compare\Item\CollectionFactory;
+use Magento\Catalog\Model\ResourceModel\Product\Compare\Item\Collection as CompareProductCollection;
+use Magento\Catalog\Model\Config;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\ProductCompareGraphQl\Model\DataProvider\Visitor;
+
+/**
+ * CompareProducts field resolver, used for GraphQL request processing.
+ */
+class CompareProducts implements ResolverInterface
+{
+
+    /**
+     * @var CollectionFactory
+     */
+    private $collectionFactory;
+
+    /**
+     * @var Config
+     */
+    private $catalogConfig;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var Visitor
+     */
+    private $visitorDataProvider;
+
+    /**
+     * @param CollectionFactory     $collectionFactory
+     * @param Config                $catalogConfig
+     * @param StoreManagerInterface $storeManager
+     * @param Visitor               $visitorDataProvider
+     */
+    public function __construct(
+        CollectionFactory $collectionFactory,
+        Config $catalogConfig,
+        StoreManagerInterface $storeManager,
+        Visitor $visitorDataProvider
+    ) {
+        $this->collectionFactory = $collectionFactory;
+        $this->catalogConfig = $catalogConfig;
+        $this->storeManager = $storeManager;
+        $this->visitorDataProvider = $visitorDataProvider;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if ($field->getName() == 'compareProducts') {
+            return [];
+        }
+
+        $collection = $this->collectionFactory->create();
+        $collection->useProductItem(true)->setStoreId($this->storeManager->getStore()->getId());
+        $collection->addAttributeToSelect($this->catalogConfig->getProductAttributes());
+        $collection->loadComparableAttributes();
+        $this->addCustomerFilter($collection);
+        $items = [];
+        foreach ($collection as $item) {
+            $productData = $item->getData();
+            $productData['model'] = $item;
+            $items[] = [
+                'item_id' => $item->getData('catalog_compare_item_id'),
+                'product' => $productData
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
+     * Add customer filter to compare product collection
+     *
+     * @param CompareProductCollection $collection
+     */
+    private function addCustomerFilter(CompareProductCollection $collection)
+    {
+        $customerId = $this->visitorDataProvider->getCustomerId();
+        if ($customerId) {
+            $collection->setCustomerId($customerId);
+        } else {
+            $collection->setVisitorId($this->visitorDataProvider->getVisitorId());
+        }
+    }
+}

--- a/app/code/Magento/ProductCompareGraphQl/Model/Resolver/RemoveProductFromCompare.php
+++ b/app/code/Magento/ProductCompareGraphQl/Model/Resolver/RemoveProductFromCompare.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ProductCompareGraphQl\Model\Resolver;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\ProductCompareGraphQl\Model\DataProvider\Visitor;
+use Magento\Catalog\Model\Product\Compare\ItemFactory;
+
+/**
+ * Resolver for Remove Product(products) from Compare List
+ */
+class RemoveProductFromCompare implements ResolverInterface
+{
+    /**
+     * @var ItemFactory
+     */
+    private $compareItemFactory;
+
+    /**
+     * @var Visitor
+     */
+    private $visitorDataProvider;
+
+    /**
+     * @param Visitor     $visitorDataProvider
+     * @param ItemFactory $compareItemFactory
+     */
+    public function __construct(
+        Visitor $visitorDataProvider,
+        ItemFactory $compareItemFactory
+    ) {
+        $this->visitorDataProvider = $visitorDataProvider;
+        $this->compareItemFactory = $compareItemFactory;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($args['input']) || !is_array($args['input']) || empty($args['input'])) {
+            throw new GraphQlInputException(__('"input" value should be specified'));
+        }
+        $result = ['result' => false, "compareProducts" => []];
+        if (!empty($args['input']['ids']) && is_array($args['input']['ids'])) {
+            foreach ($args['input']['ids'] as $id) {
+                $item = $this->compareItemFactory->create();
+                $item = $this->visitorDataProvider->addUserToItem($item);
+                $item->loadByProduct($id);
+                if ($item->getId()) {
+                    $item->delete();
+                }
+            }
+            $result = ['result' => true, "compareProducts" => []];
+        }
+        return $result;
+    }
+}

--- a/app/code/Magento/ProductCompareGraphQl/README.md
+++ b/app/code/Magento/ProductCompareGraphQl/README.md
@@ -1,0 +1,4 @@
+# ProductCompareGraphQl
+
+**ProductCompareGraphQl** provides type and resolver information for the GraphQl module
+to generate Product Compare information endpoints. Also provides endpoints for modifying a product comparison.

--- a/app/code/Magento/ProductCompareGraphQl/composer.json
+++ b/app/code/Magento/ProductCompareGraphQl/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "magento/module-product-compare-graph-ql",
+    "description": "N/A",
+    "type": "magento2-module",
+    "require": {
+        "php": "~7.1.3||~7.2.0",
+        "magento/module-catalog": "*",
+        "magento/module-graph-ql": "*",
+        "magento/framework": "*"
+    },
+    "license": [
+        "OSL-3.0",
+        "AFL-3.0"
+    ],
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "Magento\\ProductCompareGraphQl\\": ""
+        }
+    }
+}

--- a/app/code/Magento/ProductCompareGraphQl/composer.json
+++ b/app/code/Magento/ProductCompareGraphQl/composer.json
@@ -5,6 +5,7 @@
     "require": {
         "php": "~7.1.3||~7.2.0",
         "magento/module-catalog": "*",
+        "magento/module-store": "*",
         "magento/module-graph-ql": "*",
         "magento/framework": "*"
     },

--- a/app/code/Magento/ProductCompareGraphQl/etc/module.xml
+++ b/app/code/Magento/ProductCompareGraphQl/etc/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Magento_ProductCompareGraphQl" />
+</config>

--- a/app/code/Magento/ProductCompareGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/ProductCompareGraphQl/etc/schema.graphqls
@@ -1,0 +1,40 @@
+# Copyright © Magento, Inc. All rights reserved.
+# See COPYING.txt for license details.
+
+type Query {
+    compareProducts: CompareProducts @resolver(class: "Magento\\ProductCompareGraphQl\\Model\\Resolver\\CompareProducts") @doc(description: "todo")
+}
+
+type CompareProducts {
+    items: [CompareItem] @resolver(class: "Magento\\ProductCompareGraphQl\\Model\\Resolver\\CompareProducts") @doc(description: "todo")
+}
+
+type CompareItem {
+    item_id: Int
+    product: ProductInterface
+}
+
+type Mutation {
+    addProductToCompare(input: AddProductToCompareInput): AddProductToCompareOutput @resolver(class: "Magento\\ProductCompareGraphQl\\Model\\Resolver\\AddProductToCompare") @doc(description: "todo")
+    removeProductFromCompare(input: RemoveProductFromCompareInput): RemoveProductFromCompareOutput @resolver(class: "Magento\\ProductCompareGraphQl\\Model\\Resolver\\RemoveProductFromCompare") @doc(description: "todo")
+}
+
+input AddProductToCompareInput {
+    ids: [Int!]
+}
+
+type AddProductToCompareOutput {
+    result: Boolean!
+    compareProducts: CompareProducts
+}
+
+input RemoveProductFromCompareInput {
+    ids: [Int!]
+}
+
+type RemoveProductFromCompareOutput {
+    result: Boolean!
+    compareProducts: CompareProducts
+}
+
+

--- a/app/code/Magento/ProductCompareGraphQl/registration.php
+++ b/app/code/Magento/ProductCompareGraphQl/registration.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use \Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_ProductCompareGraphQl', __DIR__);

--- a/composer.json
+++ b/composer.json
@@ -156,6 +156,7 @@
         "magento/module-graph-ql": "*",
         "magento/module-catalog-graph-ql": "*",
         "magento/module-catalog-url-rewrite-graph-ql": "*",
+        "magento/module-product-compare-graph-ql": "*",
         "magento/module-configurable-product-graph-ql": "*",
         "magento/module-customer-graph-ql": "*",
         "magento/module-eav-graph-ql": "*",


### PR DESCRIPTION
Module thea incupsulates logic for GraphQl Product compare
### Description (*)
Module includes 1 query and 2 mutations.
Automated Test will be added later by @NikZh 

### Fixed Issues (if relevant)
1. magento/graphql-ce#200: Product Compare

### Manual testing scenarios (*)
1. Add product to Compare List by GraphQL
2. Add 2 different products to Compare List by GraphQL
2. Remove product from Compare List by GraphQL
4. Get a list of products to be compared by GrapgQL

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
