### PR TITLE
Fixing category tree structure corruption issue in GraphQl

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/CategoryTree.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/CategoryTree.php
@@ -102,6 +102,7 @@ class CategoryTree
         $collection->addFieldToFilter('level', ['gt' => $level]);
         $collection->addFieldToFilter('level', ['lteq' => $level + $depth - self::DEPTH_OFFSET]);
         $collection->setOrder('level');
+        $collection->setOrder('position');
         $collection->getSelect()->orWhere(
             $this->metadata->getMetadata(CategoryInterface::class)->getIdentifierField() . ' = ?',
             $rootCategoryId

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/ExtractDataFromCategoryTree.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/ExtractDataFromCategoryTree.php
@@ -38,16 +38,28 @@ class ExtractDataFromCategoryTree
     public function execute(\Iterator $iterator): array
     {
         $tree = [];
+        $referenceList = []; // A list of pointer to parents, used to know where to insert new children
+
+        // First item is laways root, create root node
+        /** @var CategoryInterface $category */
+        $category = $iterator->current();
+        $tree[$category->getId()] = $this->categoryHydrator->hydrateCategory($category);
+        $referenceList[$category->getId()] = &$tree[$category->getId()];
+
+        $iterator->next();
+
+        // Fill the rest of tree
         while ($iterator->valid()) {
             /** @var CategoryInterface $category */
             $category = $iterator->current();
+
+            $categoryData = $this->categoryHydrator->hydrateCategory($category);
+
+            $newItemIdAtItsParent = count($referenceList[$category->getParentId()]['children']);
+            $referenceList[$category->getParentId()]['children'][$newItemIdAtItsParent] = $categoryData;
+            $referenceList[$category->getId()] = &$referenceList[$category->getParentId()]['children'][$newItemIdAtItsParent];
+
             $iterator->next();
-            $nextCategory = $iterator->current();
-            $tree[$category->getId()] = $this->categoryHydrator->hydrateCategory($category);
-            $tree[$category->getId()]['model'] = $category;
-            if ($nextCategory && (int) $nextCategory->getLevel() !== (int) $category->getLevel()) {
-                $tree[$category->getId()]['children'] = $this->execute($iterator);
-            }
         }
 
         return $tree;

--- a/app/code/Magento/CatalogGraphQl/Test/Unit/Model/Resolver/Products/DataProvider/ExtractDataFromCategoryTreeTest.php
+++ b/app/code/Magento/CatalogGraphQl/Test/Unit/Model/Resolver/Products/DataProvider/ExtractDataFromCategoryTreeTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Catalog\Test\Unit\Model\Category;
+
+use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\ExtractDataFromCategoryTree;
+
+
+class ExtractDataFromCategoryTreeTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Catalog\Model\Category
+     */
+    protected $category;
+
+    /**
+     * @var \Magento\CatalogGraphQl\Model\Category\Hydrator
+     */
+    protected $categoryHydrator;
+
+    /**
+     * @var ExtractDataFromCategoryTree
+     */
+    protected $dataProvider;
+
+
+    protected function setUp()
+    {
+        $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+
+        $this->category = $this->getMockBuilder(\Magento\Catalog\Model\Category::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->categoryHydrator = $this->getMockBuilder(\Magento\CatalogGraphQl\Model\Category\Hydrator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->dataProvider = $objectManager->getObject(
+            \Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\ExtractDataFromCategoryTree::class,
+            [
+                'categoryHydrator' => $this->categoryHydrator
+            ]
+        );
+    }
+
+    public function testExtractData()
+    {
+        /**
+         * Category Structure
+         *  2
+         *  |--3
+         *  |  |--5
+         *  |
+         *  |--4
+         *     |--6
+         */
+
+
+        $cat1 = $this->createMock(\Magento\Catalog\Model\Category::class);
+        $cat1->method('getId')->willReturn('2');
+        $cat1->method('getLevel')->willReturn('1');
+        $cat1->method('getParentId')->willReturn('1');
+
+        $cat2 = $this->createMock(\Magento\Catalog\Model\Category::class);
+        $cat2->method('getId')->willReturn('3');
+        $cat2->method('getLevel')->willReturn('2');
+        $cat2->method('getParentId')->willReturn('2');
+
+        $cat3 = $this->createMock(\Magento\Catalog\Model\Category::class);
+        $cat3->method('getId')->willReturn('4');
+        $cat3->method('getLevel')->willReturn('2');
+        $cat3->method('getParentId')->willReturn('2');
+
+        $cat4 = $this->createMock(\Magento\Catalog\Model\Category::class);
+        $cat4->method('getId')->willReturn('5');
+        $cat4->method('getLevel')->willReturn('3');
+        $cat4->method('getParentId')->willReturn('3');
+
+        $cat5 = $this->createMock(\Magento\Catalog\Model\Category::class);
+        $cat5->method('getId')->willReturn('6');
+        $cat5->method('getLevel')->willReturn('3');
+        $cat5->method('getParentId')->willReturn('4');
+
+        $this->categoryHydrator->method('hydrateCategory')->will($this->returnCallback(
+            function ($category) {
+                return ['id'=>$category->getId(),'children'=>[]];
+            }
+        ));
+
+
+        $result = $this->dataProvider->execute(new \ArrayIterator([$cat1, $cat2, $cat3, $cat4, $cat5]));
+
+        $this->assertEquals(2, count($result['2']['children']), "Root category has two children");
+        $this->assertTrue(isset($result['2']['children'][0]['children']), "First sub-cat has children");
+        $this->assertTrue(isset($result['2']['children'][1]['children']), "Second sub-cat has children");
+        $this->assertEquals(1, count($result['2']['children'][0]['children']), "First sub-cat has one child");
+        $this->assertEquals(1, count($result['2']['children'][1]['children']), "Second sub-cat has one child");
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
@@ -84,7 +84,7 @@ QUERY;
         //Some sort of smoke testing
         self::assertEquals(
             'Ololo',
-            $responseDataObject->getData('category/children/7/children/1/description')
+            $responseDataObject->getData('category/children/0/children/1/description')
         );
         self::assertEquals(
             'default-category',
@@ -104,11 +104,11 @@ QUERY;
         );
         self::assertCount(
             2,
-            $responseDataObject->getData('category/children/7/children')
+            $responseDataObject->getData('category/children/0/children')
         );
         self::assertEquals(
             5,
-            $responseDataObject->getData('category/children/7/children/1/children/0/id')
+            $responseDataObject->getData('category/children/0/children/0/children/0/id')
         );
     }
 


### PR DESCRIPTION
### Description (*)
Currently running the following Graph Ql query

```
{
    category(id: 2) {
        children {
            name
            children {
                name
                children {
                    name
                    children {
                        name
                    }
                }
            }
        }
    }
}
```

Will give categories that are sorted according to their levels where last items in a level get all the children.
```
Cat 1
Cat 2
- Cat 1 subcategory
- Cat 2 subcategory 
```

### Fixed Issues (if relevant)
1. magento/graphql-ce#246: Graph Ql category tree structure is lost (children all grouped with last item)

### Manual testing scenarios (*)
Run the following query with the fixed code
```
{
    category(id: 2) {
        children {
            name
            children {
                name
                children {
                    name
                    children {
                        name
                    }
                }
            }
        }
    }
}
```
Category tree structure is now preserved
```
Cat 1
- Cat 2 subcategory
Cat 2
- Cat 1 subcategory 
```


### Contribution checklist (*)
 - [+] Pull request has a meaningful description of its purpose
 - [+] All commits are accompanied by meaningful commit messages
 - [+] All new or changed code is covered with unit/integration tests (if applicable)
 - [+] All automated tests passed successfully (all builds on Travis CI are green)
