### PR TITLE
Get downloadable products for customer

### DIFF
--- a/app/code/Magento/DownloadableGraphQl/Model/Resolver/CustomerDownloadableProducts.php
+++ b/app/code/Magento/DownloadableGraphQl/Model/Resolver/CustomerDownloadableProducts.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\DownloadableGraphQl\Model\Resolver;
+
+use Magento\DownloadableGraphQl\Model\ResourceModel\GetPurchasedDownloadableProducts;
+use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\UrlInterface;
+
+/**
+ * @inheritdoc
+ *
+ * Returns available downloadable products for customer
+ */
+class CustomerDownloadableProducts implements ResolverInterface
+{
+    /**
+     * @var GetPurchasedDownloadableProducts
+     */
+    private $getPurchasedDownloadableProducts;
+
+    /**
+     * @var UrlInterface
+     */
+    private $urlBuilder;
+
+    /**
+     * @param GetPurchasedDownloadableProducts $getPurchasedDownloadableProducts
+     * @param UrlInterface $urlBuilder
+     */
+    public function __construct(
+        GetPurchasedDownloadableProducts $getPurchasedDownloadableProducts,
+        UrlInterface $urlBuilder
+    ) {
+        $this->getPurchasedDownloadableProducts = $getPurchasedDownloadableProducts;
+        $this->urlBuilder = $urlBuilder;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        $currentUserId = $context->getUserId();
+        $purchasedProducts = $this->getPurchasedDownloadableProducts->execute($currentUserId);
+        $productsData = [];
+
+        /* The fields names are hardcoded since there's no existing name reference in the code */
+        foreach ($purchasedProducts as $purchasedProduct) {
+            if ($purchasedProduct['number_of_downloads_bought']) {
+                $remainingDownloads = $purchasedProduct['number_of_downloads_bought'] -
+                    $purchasedProduct['number_of_downloads_used'];
+            } else {
+                $remainingDownloads = __('Unlimited');
+            }
+
+            $productsData[] = [
+                'order_increment_id' => $purchasedProduct['order_increment_id'],
+                'date' => $purchasedProduct['created_at'],
+                'status' => $purchasedProduct['status'],
+                'download_url' => $this->urlBuilder->getUrl(
+                    'downloadable/download/link',
+                    ['id' => $purchasedProduct['link_hash'], '_secure' => true]
+                ),
+                'remaining_downloads' => $remainingDownloads
+            ];
+        }
+
+        return ['items' => $productsData];
+    }
+}

--- a/app/code/Magento/DownloadableGraphQl/Model/ResourceModel/GetPurchasedDownloadableProducts.php
+++ b/app/code/Magento/DownloadableGraphQl/Model/ResourceModel/GetPurchasedDownloadableProducts.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\DownloadableGraphQl\Model\ResourceModel;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Downloadable\Model\Link\Purchased\Item;
+
+/**
+ * Class GetPurchasedDownloadableProducts
+ *
+ * The model returns all purchased products for the specified customer
+ */
+class GetPurchasedDownloadableProducts
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection
+    ) {
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * Return available purchased products for customer
+     *
+     * @param int $customerId
+     * @return array
+     */
+    public function execute(int $customerId): array
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $allowedItemsStatuses = [Item::LINK_STATUS_PENDING_PAYMENT, Item::LINK_STATUS_PAYMENT_REVIEW];
+        $downloadablePurchasedTable = $connection->getTableName('downloadable_link_purchased');
+
+        /* The fields names are hardcoded since there's no existing name reference in the code */
+        $selectQuery = $connection->select()
+            ->from($downloadablePurchasedTable)
+            ->joinLeft(
+                ['item' => $connection->getTableName('downloadable_link_purchased_item')],
+                "$downloadablePurchasedTable.purchased_id = item.purchased_id"
+            )
+            ->where("$downloadablePurchasedTable.customer_id = ?", $customerId)
+            ->where('item.status NOT IN (?)', $allowedItemsStatuses);
+
+        return $connection->fetchAll($selectQuery);
+    }
+}

--- a/app/code/Magento/DownloadableGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/DownloadableGraphQl/etc/schema.graphqls
@@ -1,6 +1,22 @@
 # Copyright © Magento, Inc. All rights reserved.
 # See COPYING.txt for license details.
 
+type Query {
+    customerDownloadableProducts: customerDownloadableProducts @resolver(class: "Magento\\DownloadableGraphQl\\Model\\Resolver\\CustomerDownloadableProducts") @doc(description: "The query returns the contents of a customer's downloadable products")
+}
+
+type customerDownloadableProducts {
+    items: [customerDownloadableProduct] @doc(description: "List of downloadable items")
+}
+
+type customerDownloadableProduct {
+    order_increment_id: String
+    date: String
+    status: String
+    download_url: String
+    remaining_downloads: String
+}
+
 type DownloadableProduct implements ProductInterface, CustomizableProductInterface @doc(description: "DownloadableProduct defines a product that the customer downloads") {
     downloadable_product_samples: [DownloadableProductSamples] @resolver(class: "Magento\\DownloadableGraphQl\\Model\\Resolver\\Product\\DownloadableOptions") @doc(description: "An array containing information about samples of this downloadable product.")
     downloadable_product_links: [DownloadableProductLinks] @resolver(class: "Magento\\DownloadableGraphQl\\Model\\Resolver\\Product\\DownloadableOptions") @doc(description: "An array containing information about the links for this downloadable product")

--- a/app/code/Magento/DownloadableGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/DownloadableGraphQl/etc/schema.graphqls
@@ -6,7 +6,7 @@ type Query {
 }
 
 type customerDownloadableProducts {
-    items: [customerDownloadableProduct] @doc(description: "List of downloadable items")
+    items: [customerDownloadableProduct] @doc(description: "List of purchased downloadable items")
 }
 
 type customerDownloadableProduct {

--- a/app/code/Magento/DownloadableGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/DownloadableGraphQl/etc/schema.graphqls
@@ -2,14 +2,14 @@
 # See COPYING.txt for license details.
 
 type Query {
-    customerDownloadableProducts: customerDownloadableProducts @resolver(class: "Magento\\DownloadableGraphQl\\Model\\Resolver\\CustomerDownloadableProducts") @doc(description: "The query returns the contents of a customer's downloadable products")
+    customerDownloadableProducts: CustomerDownloadableProducts @resolver(class: "Magento\\DownloadableGraphQl\\Model\\Resolver\\CustomerDownloadableProducts") @doc(description: "The query returns the contents of a customer's downloadable products")
 }
 
-type customerDownloadableProducts {
-    items: [customerDownloadableProduct] @doc(description: "List of purchased downloadable items")
+type CustomerDownloadableProducts {
+    items: [CustomerDownloadableProduct] @doc(description: "List of purchased downloadable items")
 }
 
-type customerDownloadableProduct {
+type CustomerDownloadableProduct {
     order_increment_id: String
     date: String
     status: String


### PR DESCRIPTION
### Description (*)
This PR introduces a possibility to retrieve purchased downloadable products list for a customer.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/graphql-ce/issues/42: [Query] My Account > My Downloadable Products

### Manual testing scenarios (*)
1. Log in as a registered customer and purchase some downloadable products (place order).
2. Generate an access token for the current user (https://devdocs.magento.com/guides/v2.0/get-started/authentication/gs-authentication-token.html#request-token)
3. Use the newly generated token in the GraphQl request header and submit the following request

```
{
  customerDownloadableProducts {
    items {
      date
      status
      download_url
      remaining_downloads
    }
  }
}
```

