### PR TITLE
Mutation placeholder removed

### DIFF
--- a/app/code/Magento/GraphQl/etc/schema.graphqls
+++ b/app/code/Magento/GraphQl/etc/schema.graphqls
@@ -5,7 +5,6 @@ type Query {
 }
 
 type Mutation {
-    placeholderMutation: String @doc(description: "Mutation type cannot be declared without fields. The placeholder will be removed when at least one mutation field is declared.")
 }
 
 input FilterTypeInput @doc(description: "FilterTypeInput specifies which action will be performed in a query ") {


### PR DESCRIPTION
### Description (*)
The change in current PR removes mutation placeholder that was created before there were fields in the mutation schema. We don't need this placeholder now since a few mutation fields are already declared. 

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

