### PR TITLE
Allow introspection by default in production mode

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/IntrospectionQueryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/IntrospectionQueryTest.php
@@ -12,10 +12,10 @@ use Magento\TestFramework\TestCase\GraphQlAbstract;
 class IntrospectionQueryTest extends GraphQlAbstract
 {
     /**
-     * Tests that Introspection is disabled when not in developer mode
+     * Tests that Introspection is allowed by default
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testIntrospectionQueryWithFieldArgs()
+    public function testIntrospectionQuery()
     {
         $query
             = <<<QUERY
@@ -54,11 +54,6 @@ fragment InputValue on __InputValue {
 }
 QUERY;
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage(
-            'GraphQL response contains errors: GraphQL introspection is not allowed, but ' .
-            'the query contained __schema or __type'
-        );
-        $this->graphQlQuery($query);
+        $this->assertArrayHasKey('__schema', $this->graphQlQuery($query));
     }
 }

--- a/lib/internal/Magento/Framework/GraphQl/Query/IntrospectionConfiguration.php
+++ b/lib/internal/Magento/Framework/GraphQl/Query/IntrospectionConfiguration.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\GraphQl\Query;
+
+use Magento\Framework\App\DeploymentConfig;
+
+/**
+ * Class for fetching the availability of introspection queries
+ */
+class IntrospectionConfiguration
+{
+    const CONFIG_PATH_DISABLE_INTROSPECTION = 'graphql/disable_introspection';
+
+    /**
+     * @var DeploymentConfig
+     */
+    private $deploymentConfig;
+
+    /**
+     * @param DeploymentConfig $deploymentConfig
+     */
+    public function __construct(
+        DeploymentConfig $deploymentConfig
+    ) {
+        $this->deploymentConfig = $deploymentConfig;
+    }
+
+    /**
+     * Check the the environment config to determine if introspection should be disabled.
+     *
+     * @return int
+     */
+    public function disableIntrospection(): int
+    {
+        return (int) $this->deploymentConfig->get(self::CONFIG_PATH_DISABLE_INTROSPECTION);
+    }
+}

--- a/lib/internal/Magento/Framework/GraphQl/Query/IntrospectionConfiguration.php
+++ b/lib/internal/Magento/Framework/GraphQl/Query/IntrospectionConfiguration.php
@@ -14,7 +14,7 @@ use Magento\Framework\App\DeploymentConfig;
  */
 class IntrospectionConfiguration
 {
-    const CONFIG_PATH_DISABLE_INTROSPECTION = 'graphql/disable_introspection';
+    private const CONFIG_PATH_DISABLE_INTROSPECTION = 'graphql/disable_introspection';
 
     /**
      * @var DeploymentConfig
@@ -35,7 +35,7 @@ class IntrospectionConfiguration
      *
      * @return int
      */
-    public function disableIntrospection(): int
+    public function isIntrospectionDisabled(): int
     {
         return (int) $this->deploymentConfig->get(self::CONFIG_PATH_DISABLE_INTROSPECTION);
     }

--- a/lib/internal/Magento/Framework/GraphQl/Query/IntrospectionConfiguration.php
+++ b/lib/internal/Magento/Framework/GraphQl/Query/IntrospectionConfiguration.php
@@ -33,10 +33,10 @@ class IntrospectionConfiguration
     /**
      * Check the the environment config to determine if introspection should be disabled.
      *
-     * @return int
+     * @return bool
      */
-    public function isIntrospectionDisabled(): int
+    public function isIntrospectionDisabled(): bool
     {
-        return (int) $this->deploymentConfig->get(self::CONFIG_PATH_DISABLE_INTROSPECTION);
+        return (bool)$this->deploymentConfig->get(self::CONFIG_PATH_DISABLE_INTROSPECTION);
     }
 }

--- a/lib/internal/Magento/Framework/GraphQl/Query/QueryComplexityLimiter.php
+++ b/lib/internal/Magento/Framework/GraphQl/Query/QueryComplexityLimiter.php
@@ -11,6 +11,7 @@ use GraphQL\Validator\DocumentValidator;
 use GraphQL\Validator\Rules\DisableIntrospection;
 use GraphQL\Validator\Rules\QueryDepth;
 use GraphQL\Validator\Rules\QueryComplexity;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * QueryComplexityLimiter
@@ -34,15 +35,24 @@ class QueryComplexityLimiter
     private $queryComplexity;
 
     /**
+     * @var IntrospectionConfiguration
+     */
+    private $introspectionConfig;
+
+    /**
      * @param int $queryDepth
      * @param int $queryComplexity
+     * @param IntrospectionConfiguration $introspectionConfig
      */
     public function __construct(
         int $queryDepth,
-        int $queryComplexity
+        int $queryComplexity,
+        IntrospectionConfiguration $introspectionConfig = null
     ) {
         $this->queryDepth = $queryDepth;
         $this->queryComplexity = $queryComplexity;
+        $this->introspectionConfig = $introspectionConfig ?? ObjectManager::getInstance()
+                ->get(IntrospectionConfiguration::class);
     }
 
     /**
@@ -53,7 +63,7 @@ class QueryComplexityLimiter
     public function execute(): void
     {
         DocumentValidator::addRule(new QueryComplexity($this->queryComplexity));
-        DocumentValidator::addRule(new DisableIntrospection());
+        DocumentValidator::addRule(new DisableIntrospection($this->introspectionConfig->disableIntrospection()));
         DocumentValidator::addRule(new QueryDepth($this->queryDepth));
     }
 }

--- a/lib/internal/Magento/Framework/GraphQl/Query/QueryComplexityLimiter.php
+++ b/lib/internal/Magento/Framework/GraphQl/Query/QueryComplexityLimiter.php
@@ -11,7 +11,6 @@ use GraphQL\Validator\DocumentValidator;
 use GraphQL\Validator\Rules\DisableIntrospection;
 use GraphQL\Validator\Rules\QueryDepth;
 use GraphQL\Validator\Rules\QueryComplexity;
-use Magento\Framework\App\ObjectManager;
 
 /**
  * QueryComplexityLimiter
@@ -47,12 +46,11 @@ class QueryComplexityLimiter
     public function __construct(
         int $queryDepth,
         int $queryComplexity,
-        IntrospectionConfiguration $introspectionConfig = null
+        IntrospectionConfiguration $introspectionConfig
     ) {
         $this->queryDepth = $queryDepth;
         $this->queryComplexity = $queryComplexity;
-        $this->introspectionConfig = $introspectionConfig ?? ObjectManager::getInstance()
-                ->get(IntrospectionConfiguration::class);
+        $this->introspectionConfig = $introspectionConfig;
     }
 
     /**
@@ -63,7 +61,7 @@ class QueryComplexityLimiter
     public function execute(): void
     {
         DocumentValidator::addRule(new QueryComplexity($this->queryComplexity));
-        DocumentValidator::addRule(new DisableIntrospection($this->introspectionConfig->disableIntrospection()));
+        DocumentValidator::addRule(new DisableIntrospection($this->introspectionConfig->isIntrospectionDisabled()));
         DocumentValidator::addRule(new QueryDepth($this->queryDepth));
     }
 }

--- a/lib/internal/Magento/Framework/GraphQl/Query/QueryComplexityLimiter.php
+++ b/lib/internal/Magento/Framework/GraphQl/Query/QueryComplexityLimiter.php
@@ -61,7 +61,7 @@ class QueryComplexityLimiter
     public function execute(): void
     {
         DocumentValidator::addRule(new QueryComplexity($this->queryComplexity));
-        DocumentValidator::addRule(new DisableIntrospection($this->introspectionConfig->isIntrospectionDisabled()));
+        DocumentValidator::addRule(new DisableIntrospection((int) $this->introspectionConfig->isIntrospectionDisabled()));
         DocumentValidator::addRule(new QueryDepth($this->queryDepth));
     }
 }


### PR DESCRIPTION
### Description (*)
Adds env.php parameter for disabling introspection:
```php
...
    'graphql' => [
        'disable_introspection' => true,
    ],
...
```

### Fixed Issues (if relevant)
1. magento/graphql-ce#232: GraphQL tools cannot perform "standard introspection query" in production mode

### Manual testing scenarios (*)
#### Validate disabled
1. Enable production mode
2. Add the following to `env.php`:
```php
...
    'graphql' => [
        'disable_introspection' => true,
    ],
...
```
3. Query:
```graphql
{
  __schema {
    types {
      name
      interfaces {
        name
        description
      }
    }
  }
}
```
4. Expect error message `GraphQL introspection is not allowed, but the query contained __schema or __type`

#### Validate enabled
1. Enable production mode
2. Add the following to `env.php`, or ensure path `graphql/disable_introspection` is not set:
```php
...
    'graphql' => [
        'disable_introspection' => false,
    ],
...
```
3. Query:
```graphql
{
  __schema {
    types {
      name
      interfaces {
        name
        description
      }
    }
  }
}
```
4. Expect valid response

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
