### PR TITLE
Fixed non existant category with products issue

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/CategoryTree.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/CategoryTree.php
@@ -72,7 +72,7 @@ class CategoryTree implements ResolverInterface
 
         $rootCategoryId = $this->getCategoryId($args);
         $categoriesTree = $this->categoryTree->getTree($info, $rootCategoryId);
-        if (!empty($categoriesTree)) {
+        if (!empty($categoriesTree) && ($categoriesTree->count() > 0)) {
             $result = $this->extractDataFromCategoryTree->execute($categoriesTree);
             return current($result);
         } else {

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/CategoryTree.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/CategoryTree.php
@@ -11,6 +11,7 @@ use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\ExtractDataFromC
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 
 /**
@@ -72,11 +73,12 @@ class CategoryTree implements ResolverInterface
 
         $rootCategoryId = $this->getCategoryId($args);
         $categoriesTree = $this->categoryTree->getTree($info, $rootCategoryId);
-        if (!empty($categoriesTree) && ($categoriesTree->count() > 0)) {
-            $result = $this->extractDataFromCategoryTree->execute($categoriesTree);
-            return current($result);
-        } else {
-            return null;
+
+        if (empty($categoriesTree) || ($categoriesTree->count() == 0)) {
+            throw new GraphQlNoSuchEntityException(__('Category doesn\'t exist'));
         }
+
+        $result = $this->extractDataFromCategoryTree->execute($categoriesTree);
+        return current($result);
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
@@ -10,7 +10,7 @@ namespace Magento\GraphQl\Catalog;
 use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Catalog\Model\ResourceModel\Category\Collection as CategoryCollection;
 use Magento\Framework\DataObject;
-use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
+use Magento\TestFramework\TestCase\GraphQl\ResponseContainsErrorsException;
 use Magento\TestFramework\TestCase\GraphQlAbstract;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
@@ -124,7 +124,7 @@ QUERY;
 }
 QUERY;
 
-        $this->expectException(GraphQlNoSuchEntityException::class);
+        $this->expectException(ResponseContainsErrorsException::class);
         $this->expectExceptionMessage('GraphQL response contains errors: Category doesn\'t exist');
         $this->graphQlQuery($query);
     }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
@@ -112,6 +112,21 @@ QUERY;
         );
     }
 
+    public function testNonExistentCategoryWithProductCount()
+    {
+        $query = <<<QUERY
+{
+  category(id: 99) {
+      product_count
+    }
+}
+QUERY;
+
+        $response = $this->graphQlQuery($query);
+        $expectedResponse = ['category' => null];
+        $this->assertEquals($expectedResponse, $response);
+    }
+
     /**
      * @magentoApiDataFixture Magento/Catalog/_files/categories.php
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
@@ -123,7 +123,7 @@ QUERY;
 QUERY;
 
         $response = $this->graphQlQuery($query);
-        $expectedResponse = ['category' => null];
+        $expectedResponse = ['errors' => ['message' => 'Category doesn\'t exist']];
         $this->assertEquals($expectedResponse, $response);
     }
 

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
@@ -10,10 +10,12 @@ namespace Magento\GraphQl\Catalog;
 use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Catalog\Model\ResourceModel\Category\Collection as CategoryCollection;
 use Magento\Framework\DataObject;
+use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
 use Magento\TestFramework\TestCase\GraphQlAbstract;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\TestFramework\ObjectManager;
+
 
 class CategoryTest extends GraphQlAbstract
 {
@@ -122,9 +124,9 @@ QUERY;
 }
 QUERY;
 
-        $response = $this->graphQlQuery($query);
-        $expectedResponse = ['errors' => ['message' => 'Category doesn\'t exist']];
-        $this->assertEquals($expectedResponse, $response);
+        $this->expectException(GraphQlNoSuchEntityException::class);
+        $this->expectExceptionMessage('GraphQL response contains errors: Category doesn\'t exist');
+        $this->graphQlQuery($query);
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The category query for category that doesn't exist with products count shouldn't throw an error.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/graphql-ce#310: Non existent category with products query results in an error

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Query:

```
{
  category(id: 99) {
    product_count
  }
}
```

2. Result

```
{
  "data": {
    "category": null
  }
}
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
