### PR TITLE
Fix region_id update in updateCustomerAddress mutation

### DIFF
--- a/app/code/Magento/CustomerGraphQl/Model/Resolver/UpdateCustomerAddress.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Resolver/UpdateCustomerAddress.php
@@ -109,6 +109,10 @@ class UpdateCustomerAddress implements ResolverInterface
     {
         $address = $this->getCustomerAddressForUser->execute($addressId, $customerId);
         $this->dataObjectHelper->populateWithArray($address, $addressData, AddressInterface::class);
+        if (isset($addressData['region']['region_id'])) {
+            $address->setRegionId($address->getRegion()->getRegionId());
+        }
+
         return $this->addressRepository->save($address);
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerAddressTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerAddressTest.php
@@ -218,13 +218,12 @@ MUTATION;
         ];
         $this->assertResponseFields($actualResponse, $assertionMap);
         $this->assertTrue(is_array([$actualResponse['region']]), "region field must be of an array type.");
-        // https://github.com/magento/graphql-ce/issues/270
-//        $assertionRegionMap = [
-//            ['response_field' => 'region', 'expected_value' => $address->getRegion()->getRegion()],
-//            ['response_field' => 'region_code', 'expected_value' => $address->getRegion()->getRegionCode()],
-//            ['response_field' => 'region_id', 'expected_value' => $address->getRegion()->getRegionId()]
-//        ];
-//        $this->assertResponseFields($actualResponse['region'], $assertionRegionMap);
+        $assertionRegionMap = [
+            ['response_field' => 'region', 'expected_value' => $address->getRegion()->getRegion()],
+            ['response_field' => 'region_code', 'expected_value' => $address->getRegion()->getRegionCode()],
+            ['response_field' => 'region_id', 'expected_value' => $address->getRegion()->getRegionId()]
+        ];
+        $this->assertResponseFields($actualResponse['region'], $assertionRegionMap);
     }
 
     /**


### PR DESCRIPTION
### Description (*)
This commit maps `region/region_id` to `AddressInterface:regionId` when
provided as input.

The `AddressInterface` contains both `region` and `regionId` properties which
are mapped to `\Magento\Customer\Model\Address` by the
`AddressRepositoryInterface`.

After populating an existing customer address with the user input for `region`,
the exting `regionId` was still set on the `AddressInterface`. When saving
the `region` property is mapped to the model before `regionId`.

https://github.com/magento/magento2/blob/1a92f1c1609445c7b6b107a165d387e306f2f779/app/code/Magento/Customer/Model/Address.php#L141-L167

### Fixed Issues (if relevant)
1. magento/graphql-ce#270: [My Account] Add possibility to change Region via 'updateCustomerAddress' mutation

### Manual testing scenarios (*)
1. Create user with saved address using a country with pre-defined regions such as US or CA
2. Update the address region id via mutation:
```graphql
mutation {
  updateCustomerAddress(
    id: {{addressId}
    input: {
      region: {
        region_id: {{newRegionId}}
      }
    }
  ) {
    id
    region {
      region
      region_id
      region_code
    }
  }
}
```
3. The mutation output should reflect the region id provided in the mutation.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
