### PR TITLE
[ThemeGraphql] Getting values from StoreConfig is not possible

### DIFF
--- a/app/code/Magento/ThemeGraphQl/etc/graphql/di.xml
+++ b/app/code/Magento/ThemeGraphQl/etc/graphql/di.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\StoreGraphQl\Model\Resolver\Store\StoreConfigDataProvider">
+        <arguments>
+            <argument name="extendedConfigData" xsi:type="array">
+                <item name="head_shortcut_icon" xsi:type="string">design/head/shortcut_icon</item>
+                <item name="default_title" xsi:type="string">design/head/default_title</item>
+                <item name="title_prefix" xsi:type="string">design/head/title_prefix</item>
+                <item name="title_suffix" xsi:type="string">design/head/title_suffix</item>
+                <item name="default_description" xsi:type="string">design/head/default_description</item>
+                <item name="default_keywords" xsi:type="string">design/head/default_keywords</item>
+                <item name="head_includes" xsi:type="string">design/head/includes</item>
+                <item name="demonotice" xsi:type="string">design/head/demonotice</item>
+                <item name="header_logo_src" xsi:type="string">design/header/logo_src</item>
+                <item name="logo_width" xsi:type="string">design/header/logo_width</item>
+                <item name="logo_height" xsi:type="string">design/header/logo_height</item>
+                <item name="logo_alt" xsi:type="string">design/header/logo_alt</item>
+                <item name="welcome" xsi:type="string">design/header/welcome</item>
+                <item name="absolute_footer" xsi:type="string">design/footer/absolute_footer</item>
+                <item name="copyright" xsi:type="string">design/footer/copyright</item>
+            </argument>
+        </arguments>
+    </type>
+</config>


### PR DESCRIPTION
### Description (*)
This PR aims to allow developers to get store design configuration (from Html Head, Footer and Header) information using Graphql.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/graphql-ce#317: [ThemeGraphql] Getting values from StoreConfig is not possible

### Manual testing scenarios (*)
Provided in original issue description

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
