### PR TITLE
Changed hard coded "configurable" to Configurable::TYPE_CODE

### DIFF
--- a/app/code/Magento/ConfigurableProductGraphQl/Model/ConfigurableProductTypeResolver.php
+++ b/app/code/Magento/ConfigurableProductGraphQl/Model/ConfigurableProductTypeResolver.php
@@ -16,12 +16,18 @@ use Magento\ConfigurableProduct\Model\Product\Type\Configurable as Type;
 class ConfigurableProductTypeResolver implements TypeResolverInterface
 {
     /**
+     * Configurable product type resolver code
+     */
+    const TYPE_RESOLVER = 'ConfigurableProduct';
+
+    /**
      * {@inheritdoc}
      */
     public function resolveType(array $data) : string
     {
         if (isset($data['type_id']) && $data['type_id'] == Type::TYPE_CODE) {
-            return 'ConfigurableProduct';
+            return self::TYPE_RESOLVER;
+
         }
         return '';
     }

--- a/app/code/Magento/ConfigurableProductGraphQl/Model/ConfigurableProductTypeResolver.php
+++ b/app/code/Magento/ConfigurableProductGraphQl/Model/ConfigurableProductTypeResolver.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\ConfigurableProductGraphQl\Model;
 
 use Magento\Framework\GraphQl\Query\Resolver\TypeResolverInterface;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable as Type;
 
 /**
  * {@inheritdoc}
@@ -19,7 +20,7 @@ class ConfigurableProductTypeResolver implements TypeResolverInterface
      */
     public function resolveType(array $data) : string
     {
-        if (isset($data['type_id']) && $data['type_id'] == 'configurable') {
+        if (isset($data['type_id']) && $data['type_id'] == Type::TYPE_CODE) {
             return 'ConfigurableProduct';
         }
         return '';


### PR DESCRIPTION
Description (*)
Changed hard coded "configurable" to Magento\ConfigurableProduct\Model\Product\Type\Configurable:: TYPE_CODE value in Magento\ConfigurableProductGraphQl\Model\ConfigurableProductTypeResolver::resolveType()

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
