### PR TITLE
graphQl-336: Magento/CatalogGraphQl/Model/Category/LevelCalculator class has fields declared dynamically

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Category/LevelCalculator.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Category/LevelCalculator.php
@@ -16,6 +16,16 @@ use Magento\Catalog\Model\ResourceModel\Category;
 class LevelCalculator
 {
     /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var Category
+     */
+    private $resourceCategory;
+
+    /**
      * @param ResourceConnection $resourceConnection
      * @param Category $resourceCategory
      */
@@ -39,6 +49,7 @@ class LevelCalculator
         $select = $connection->select()
             ->from($this->resourceConnection->getTableName('catalog_category_entity'), 'level')
             ->where($this->resourceCategory->getLinkField() . " = ?", $rootCategoryId);
+
         return (int) $connection->fetchOne($select);
     }
 }


### PR DESCRIPTION
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/graphql-ce#336
