### PR TITLE
Added label from store view

### DIFF
--- a/app/code/Magento/ConfigurableProductGraphQl/Model/Options/Collection.php
+++ b/app/code/Magento/ConfigurableProductGraphQl/Model/Options/Collection.php
@@ -124,6 +124,8 @@ class Collection
             $this->attributeMap[$productId][$attribute->getId()]['attribute_code']
                 = $attribute->getProductAttribute()->getAttributeCode();
             $this->attributeMap[$productId][$attribute->getId()]['values'] = $attributeData['options'];
+            $this->attributeMap[$productId][$attribute->getId()]['label']
+                = $attribute->getProductAttribute()->getStoreLabel();
         }
 
         return $this->attributeMap;

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/ConfigurableProductFrontendLabelAttributeTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/ConfigurableProductFrontendLabelAttributeTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\GraphQl\ConfigurableProduct;
+
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+/**
+ * Class ConfigurableProductFrontendLabelAttributeTest
+ *
+ * @package Magento\GraphQl\ConfigurableProduct
+ */
+class ConfigurableProductFrontendLabelAttributeTest extends GraphQlAbstract
+{
+    /**
+     * @magentoApiDataFixture Magento/ConfigurableProduct/_files/product_configurable_with_frontend_label_attribute.php
+     */
+    public function testGetFrontendLabelAttribute()
+    {
+        $expectLabelValue = 'Default Store View label';
+        $productSku = 'configurable';
+
+        $query = <<<QUERY
+{
+  products(filter: {sku: {eq: "{$productSku}"}}) {
+    items {
+      name
+        ... on ConfigurableProduct{
+        configurable_options{
+          id
+          label
+        }
+      }
+    }
+  }
+}
+QUERY;
+        $response = $this->graphQlQuery($query);
+
+        $this->assertArrayHasKey('products', $response);
+        $this->assertArrayHasKey('items', $response['products']);
+        $this->assertArrayHasKey(0, $response['products']['items']);
+        
+        $product = $response['products']['items'][0];
+        $this->assertArrayHasKey('configurable_options', $product);
+        $this->assertArrayHasKey(0, $product['configurable_options']);
+        $this->assertArrayHasKey('label', $product['configurable_options'][0]);
+
+        $option = $product['configurable_options'][0];
+        $this->assertEquals($expectLabelValue, $option['label']);
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/ConfigurableProductFrontendLabelAttributeTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/ConfigurableProductFrontendLabelAttributeTest.php
@@ -3,7 +3,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 declare(strict_types=1);
 
 namespace Magento\GraphQl\ConfigurableProduct;

--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/_files/product_configurable_with_frontend_label_attribute.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/_files/product_configurable_with_frontend_label_attribute.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 use Magento\Eav\Model\Entity\Attribute\FrontendLabel;
 use Magento\TestFramework\Helper\Bootstrap;

--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/_files/product_configurable_with_frontend_label_attribute.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/_files/product_configurable_with_frontend_label_attribute.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Magento\Eav\Model\Entity\Attribute\FrontendLabel;
+use Magento\TestFramework\Helper\Bootstrap;
+
+require __DIR__ . '/configurable_products.php';
+
+// Add frontend label to created attribute:
+$frontendLabelAttribute = Bootstrap::getObjectManager()->get(FrontendLabel::class);
+$frontendLabelAttribute->setStoreId(1);
+$frontendLabelAttribute->setLabel('Default Store View label');
+
+$frontendLabels = $attribute->getFrontendLabels();
+$frontendLabels[] = $frontendLabelAttribute;
+
+$attribute->setFrontendLabels($frontendLabels);
+$attributeRepository->save($attribute);

--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/_files/product_configurable_with_frontend_label_attribute_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/_files/product_configurable_with_frontend_label_attribute_rollback.php
@@ -3,5 +3,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 require __DIR__ . '/configurable_products_rollback.php';

--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/_files/product_configurable_with_frontend_label_attribute_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/_files/product_configurable_with_frontend_label_attribute_rollback.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+require __DIR__ . '/configurable_products_rollback.php';


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
PR for issue #250 Configurable Options Label doesn't return the Store View Label
This PR added functionality to show store label in label response

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
#250: Configurable Options Label doesn't return the Store View Label


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Request: Store Label "Custom Color", Default Store Label "Color"

```
{
  products(filter: { sku: { eq: "Test Configurable" } }) {
    items {
      name
      ... on ConfigurableProduct {
        configurable_options {
          attribute_code
          id
          label
        }
      }
    }
  }
}
```
Response:

```
{
  "data": {
    "products": {
      "items": [
        {
          "name": "Test Configurable",
          "configurable_options": [
            {
              "attribute_code": "color",
              "id": 35,
              "label": "Custom Color"
            }
          ]
        }
      ]
    }
  }
}
```
Response with empty Store Label

```
{
  "data": {
    "products": {
      "items": [
        {
          "name": "Test Configurable",
          "configurable_options": [
            {
              "attribute_code": "color",
              "id": 35,
              "label": "Color"
            }
          ]
        }
      ]
    }
  }
}
```
Also tested with different store and with branch 2.3-develop.
Api-functional test included.
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
