### PR TITLE
GraphQL-272: [My Account] Added test address extractor

### DIFF
--- a/app/code/Magento/CustomerGraphQl/Model/Customer/Address/CustomerAddressCreateDataValidator.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/Address/CustomerAddressCreateDataValidator.php
@@ -21,12 +21,12 @@ class CustomerAddressCreateDataValidator
     private $customerAddressValidator;
 
     /**
-     * @param CustomerAddressValidator $customerAddressValidator
+     * @param CustomerAddressValidator $addressValidator
      */
     public function __construct(
-        CustomerAddressValidator $customerAddressValidator
+        CustomerAddressValidator $addressValidator
     ) {
-        $this->customerAddressValidator = $customerAddressValidator;
+        $this->customerAddressValidator = $addressValidator;
     }
 
     /**
@@ -40,13 +40,8 @@ class CustomerAddressCreateDataValidator
 
         $errorInput = [];
 
-<<<<<<< HEAD
         if ($errors !== true) {
             foreach ($errors as $messageText) {
-=======
-        if (!empty($messages)) {
-            foreach ($messages as $messageText) {
->>>>>>> GraphQL-272: [My Account] Removed temporary allowed attribute logic. Added logic for the Update customer address methog
                 $errorInput[] = $messageText;
             }
         }

--- a/app/code/Magento/CustomerGraphQl/Model/Customer/Address/CustomerAddressCreateDataValidator.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/Address/CustomerAddressCreateDataValidator.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CustomerGraphQl\Model\Customer\Address;
+
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\CustomerGraphQl\Model\Customer\Address\Validator as CustomerAddressValidator;
+
+/**
+ * Customer address create data validator
+ */
+class CustomerAddressCreateDataValidator
+{
+    /**
+     * @var CustomerAddressValidator
+     */
+    private $customerAddressValidator;
+
+    /**
+     * @param CustomerAddressValidator $customerAddressValidator
+     */
+    public function __construct(
+        CustomerAddressValidator $customerAddressValidator
+    ) {
+        $this->customerAddressValidator = $customerAddressValidator;
+    }
+
+    /**
+     * @param array $addressData
+     * @throws GraphQlInputException
+     * @throws \Exception
+     */
+    public function validate(array $addressData): void
+    {
+        $errors = $this->customerAddressValidator->validateAddress($addressData);
+
+        $errorInput = [];
+
+        if ($errors !== true) {
+            foreach ($errors as $messageText) {
+                $errorInput[] = $messageText;
+            }
+        }
+
+        if ($errorInput) {
+            throw new GraphQlInputException(
+                __('Required parameters are missing: %1', [implode(', ', $errorInput)])
+            );
+        }
+    }
+}

--- a/app/code/Magento/CustomerGraphQl/Model/Customer/Address/CustomerAddressUpdateDataValidator.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/Address/CustomerAddressUpdateDataValidator.php
@@ -11,9 +11,9 @@ use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\CustomerGraphQl\Model\Customer\Address\Validator as CustomerAddressValidator;
 
 /**
- * Customer address create data validator
+ * Customer address update data validator. Patch update is allowed
  */
-class CustomerAddressCreateDataValidator
+class CustomerAddressUpdateDataValidator
 {
     /**
      * @var CustomerAddressValidator
@@ -21,18 +21,20 @@ class CustomerAddressCreateDataValidator
     private $customerAddressValidator;
 
     /**
-     * @param CustomerAddressValidator $customerAddressValidator
+     * @param CustomerAddressValidator $addressValidator
      */
     public function __construct(
-        CustomerAddressValidator $customerAddressValidator
+        CustomerAddressValidator $addressValidator
     ) {
-        $this->customerAddressValidator = $customerAddressValidator;
+        $this->customerAddressValidator = $addressValidator;
     }
 
     /**
+     * Validate customer address update data
+     *
      * @param array $addressData
+     * @return void
      * @throws GraphQlInputException
-     * @throws \Exception
      */
     public function validate(array $addressData): void
     {
@@ -40,13 +42,8 @@ class CustomerAddressCreateDataValidator
 
         $errorInput = [];
 
-<<<<<<< HEAD
         if ($errors !== true) {
             foreach ($errors as $messageText) {
-=======
-        if (!empty($messages)) {
-            foreach ($messages as $messageText) {
->>>>>>> GraphQL-272: [My Account] Removed temporary allowed attribute logic. Added logic for the Update customer address methog
                 $errorInput[] = $messageText;
             }
         }

--- a/app/code/Magento/CustomerGraphQl/Model/Customer/Address/Validator.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/Address/Validator.php
@@ -48,10 +48,18 @@ class Validator
         /** @var Form $addressForm */
         $addressForm = $this->formFactory->create(
             'customer_address',
-            'customer_address_edit'
+            'customer_address_edit',
+            [],
+            false,
+            false
         );
 
         $addressData = $addressForm->extractData($request);
+        //$addressData = $addressForm->compactData($addressData);
+
+        $addressData['region'] = $addressData['region']['region'] ?? null;
+        $addressData['region_id'] = $addressData['region']['region_id'] ?? null;
+        $addressData['region_code'] = $addressData['region']['region_code'] ?? null;
 
         $errors = $addressForm->validateData($addressData);
         if ($errors !== true) {

--- a/app/code/Magento/CustomerGraphQl/Model/Customer/Address/Validator.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/Address/Validator.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CustomerGraphQl\Model\Customer\Address;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\RequestInterfaceFactory;
+use Magento\Customer\Model\Metadata\FormFactory;
+use Magento\Customer\Model\Metadata\Form;
+
+class Validator
+{
+    /**
+     * @var RequestInterfaceFactory
+     */
+    private $requestFactory;
+
+    /**
+     * @var FormFactory
+     */
+    private $formFactory;
+
+    /**
+     * @param RequestInterfaceFactory $requestFactory
+     * @param FormFactory $formFactory
+     */
+    public function __construct(
+        RequestInterfaceFactory $requestFactory,
+        FormFactory $formFactory
+    ) {
+        $this->requestFactory = $requestFactory;
+        $this->formFactory = $formFactory;
+    }
+
+    /**
+     * @param array $addressData
+     * @return array|bool
+     */
+    public function validateAddress($addressData)
+    {
+        $request = $this->createNewRequest();
+        $request->setParams($addressData);
+
+        /** @var Form $addressForm */
+        $addressForm = $this->formFactory->create(
+            'customer_address',
+            'customer_address_edit'
+        );
+
+        $addressData = $addressForm->extractData($request);
+
+        $errors = $addressForm->validateData($addressData);
+        if ($errors !== true) {
+            $messages = [];
+            foreach ($errors as $error) {
+                $messages[] = $error;
+            }
+        }
+
+        return $messages ?? true;
+    }
+
+    /**
+     * @return RequestInterface
+     */
+    private function createNewRequest()
+    {
+        return $this->requestFactory->create();
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CreateCustomerAddressTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CreateCustomerAddressTest.php
@@ -167,7 +167,7 @@ MUTATION;
      *
      * @magentoApiDataFixture Magento/Customer/_files/customer_without_addresses.php
      * @expectedException \Exception
-     * @expectedExceptionMessage Required parameters are missing: firstname
+     * @expectedExceptionMessage Required parameters are missing: "First Name" is a required value.
      */
     public function testCreateCustomerAddressWithMissingAttribute()
     {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CreateCustomerAddressTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CreateCustomerAddressTest.php
@@ -167,7 +167,7 @@ MUTATION;
      *
      * @magentoApiDataFixture Magento/Customer/_files/customer_without_addresses.php
      * @expectedException \Exception
-     * @expectedExceptionMessage Required parameters are missing: "First Name" is a required value.
+     * @expectedExceptionMessage Required parameters are missing: firstname
      */
     public function testCreateCustomerAddressWithMissingAttribute()
     {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerAddressTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerAddressTest.php
@@ -168,7 +168,7 @@ MUTATION;
      * @magentoApiDataFixture Magento/Customer/_files/customer.php
      * @magentoApiDataFixture Magento/Customer/_files/customer_address.php
      * @expectedException \Exception
-     * @expectedExceptionMessage Required parameters are missing: firstname
+     * @expectedExceptionMessage Required parameters are missing: "First Name" is a required value., "Street Address" is a required value., "City" is a required value., "Country" is a required value., "Zip/Postal Code" is a required value., "Phone Number" is a required value.
      */
     public function testUpdateCustomerAddressWithMissingAttribute()
     {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerAddressTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerAddressTest.php
@@ -168,7 +168,7 @@ MUTATION;
      * @magentoApiDataFixture Magento/Customer/_files/customer.php
      * @magentoApiDataFixture Magento/Customer/_files/customer_address.php
      * @expectedException \Exception
-     * @expectedExceptionMessage Required parameters are missing: "First Name" is a required value., "Street Address" is a required value., "City" is a required value., "Country" is a required value., "Zip/Postal Code" is a required value., "Phone Number" is a required value.
+     * @expectedExceptionMessage Required parameters are missing: firstname
      */
     public function testUpdateCustomerAddressWithMissingAttribute()
     {
@@ -187,6 +187,9 @@ mutation {
   }
 }
 MUTATION;
+
+
+
         $this->graphQlQuery($mutation, [], '', $this->getCustomerAuthHeaders($userName, $password));
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Created a new PR for Create new address through GraphQL request. Started from Validate address on Created Address action.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<[272](https://github.com/magento/graphql-ce/issues/272)>: [My Account] Add support of Customer Address attributes

### GraphQL test query:
```
createCustomerAddress (
    input: {
      region:{
        region:"Arizona",
        region_id:4,
        region_code:"AZ"
      },
      firstname:"Oli",
      lastname: "Ne",
      telephone:"123456789",
      street: "123 as a look ek",
      city:"CPH",
      country_id:DK,
      postcode:"1600",
      default_shipping: true,
      default_billing:true,
      custom_attributes: {
        attribute_code: "de",
        value:"new dan"
      }
    }
  ) {
    id
    customer_id
  }
```

Please give me your opinion and tell me if I'm doing something wrong.