### PR TITLE
Change CustomizableOptionInput input value as Int

### DIFF
--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -174,7 +174,7 @@ input SimpleProductCartItemInput {
 
 input CustomizableOptionInput {
     id: Int!
-    value: String!
+    value: Int!
 }
 
 type AddSimpleProductsToCartOutput {


### PR DESCRIPTION
### Description
For custom option value always integer. But in graphql input requires as String.
Is there any reason for this value set as String?
```
input CustomizableOptionInput {
    id: Int!
    value: String!
}
```
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
