### PR TITLE
Query Cart returns internal server error if configurable product was added

### DIFF
--- a/app/code/Magento/QuoteGraphQl/etc/di.xml
+++ b/app/code/Magento/QuoteGraphQl/etc/di.xml
@@ -12,6 +12,7 @@
             <argument name="supportedTypes" xsi:type="array">
                 <item name="simple" xsi:type="string">SimpleCartItem</item>
                 <item name="virtual" xsi:type="string">VirtualCartItem</item>
+                <item name="configurable" xsi:type="string">ConfigurableCartItem</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
### Description (*)
Issue https://github.com/magento/graphql-ce/issues/380

### Manual testing scenarios (*)
### Preconditions (*)
1. Simple Product with SKU simple-product is created
2. Configurable Product with 2 color options: "black" and "white" is created

### Steps to reproduce (*)
1. Add simple-product to the cart
2. Add configurable product with color "white"
3. Get `$cart_id` like this:

```sql
SELECT masked_id FROM <YOUR DBNAME>.quote_id_mask ORDER BY entity_id DESC LIMIT 1;
```

1. Execute the query

```graphql
query showCartDetails(
  $cart_id: String!
) {
  Cart(
    cart_id: $cart_id
  ) {
    items {
      id
      qty
      ... on SimpleCartItem {
        product {
          name
        }
      }
      ... on ConfigurableCartItem {
        product {
          name
        }
      }
    }
  }
}
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
