### PR TITLE
Save country when creating new quote addresses

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Cart/SetBillingAddressOnCart.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/SetBillingAddressOnCart.php
@@ -93,6 +93,7 @@ class SetBillingAddressOnCart
             );
         }
         if (null === $customerAddressId) {
+            $addressInput['country_id'] = $addressInput['country_code'] ?? '';
             $billingAddress = $this->addressModel->addData($addressInput);
         } else {
             $this->checkCustomerAccount->execute($context->getUserId(), $context->getUserType());

--- a/app/code/Magento/QuoteGraphQl/Model/Cart/SetShippingAddressOnCart.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/SetShippingAddressOnCart.php
@@ -87,6 +87,7 @@ class SetShippingAddressOnCart implements SetShippingAddressesOnCartInterface
             );
         }
         if (null === $customerAddressId) {
+            $addressInput['country_id'] = $addressInput['country_code'] ?? '';
             $shippingAddress = $this->addressModel->addData($addressInput);
         } else {
             $this->checkCustomerAccount->execute($context->getUserId(), $context->getUserType());

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/SetBillingAddressOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/SetBillingAddressOnCartTest.php
@@ -88,6 +88,10 @@ mutation {
         city
         postcode
         telephone
+        country {
+          code
+          label
+        }
       }
     }
   }
@@ -140,6 +144,10 @@ mutation {
         city
         postcode
         telephone
+        country {
+          code
+          label
+        }
       }
       shipping_addresses {
         firstname
@@ -149,6 +157,10 @@ mutation {
         city
         postcode
         telephone
+        country {
+          code
+          label
+        }
       }
     }
   }
@@ -234,6 +246,10 @@ mutation {
         city
         postcode
         telephone
+        country {
+          code
+          label
+        }
       }
     }
   }
@@ -413,7 +429,8 @@ QUERY;
             ['response_field' => 'street', 'expected_value' => [0 => 'test street 1', 1 => 'test street 2']],
             ['response_field' => 'city', 'expected_value' => 'test city'],
             ['response_field' => 'postcode', 'expected_value' => '887766'],
-            ['response_field' => 'telephone', 'expected_value' => '88776655']
+            ['response_field' => 'telephone', 'expected_value' => '88776655'],
+            ['response_field' => 'country', 'expected_value' => ['code' => 'US', 'label' => 'US']],
         ];
 
         $this->assertResponseFields($billingAddressResponse, $assertionMap);

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/SetShippingAddressOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/SetShippingAddressOnCartTest.php
@@ -90,6 +90,10 @@ mutation {
         city
         postcode
         telephone
+        country {
+          code
+          label
+        }
       }
     }
   }
@@ -176,6 +180,10 @@ mutation {
         city
         postcode
         telephone
+        country {
+          label
+          code
+        }
       }
     }
   }
@@ -462,7 +470,8 @@ QUERY;
             ['response_field' => 'street', 'expected_value' => [0 => 'test street 1', 1 => 'test street 2']],
             ['response_field' => 'city', 'expected_value' => 'test city'],
             ['response_field' => 'postcode', 'expected_value' => '887766'],
-            ['response_field' => 'telephone', 'expected_value' => '88776655']
+            ['response_field' => 'telephone', 'expected_value' => '88776655'],
+            ['response_field' => 'country', 'expected_value' => ['code' => 'US', 'label' => 'US']],
         ];
 
         $this->assertResponseFields($shippingAddressResponse, $assertionMap);


### PR DESCRIPTION
### Description (*)
Properly set the `country_id` value on quote address objects created using the shipping and billing method mutations.

### Fixed Issues (if relevant)
1. magento/graphql-ce#389: Country Not Saved With New Quote Addresses

### Manual testing scenarios (*)
1. Create empty cart
```graphql
mutation {
  createEmptyCart
}
```
2. Add new shipping address on cart
```graphql
mutation SetShippingAddress($cartId:String!) {
  setShippingAddressesOnCart(input: {
    cart_id:$cartId
    shipping_addresses:[{
      address:{
        city:"Nowhere"
        country_code:"US"
        firstname:"Patrick"
        lastname:"McLain"
        postcode:"49920"
        region:"MI"
        save_in_address_book:false
        street:["123 Abc Ct"]
        telephone:"5555555555"
      }
    }]
  }) {
    cart {
      cart_id
      shipping_addresses {
        country {
          code
          label
        }
      }
    }
  }
}
```
3. Set billing address on cart
```graphql
mutation SetBillingAddress($cartId:String!) {
  setBillingAddressOnCart(input: {
    cart_id:$cartId
    billing_addresses:{
      address:{
        city:"Nowhere"
        country_code:"US"
        firstname:"Patrick"
        lastname:"McLain"
        postcode:"49920"
        region:"MI"
        save_in_address_book:false
        street:["123 Abc Ct"]
        telephone:"5555555555"
      }
    }
  }) {
    cart {
      cart_id
      billing_address {
        country {
          code
          label
        }
      }
    }
  }
}
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
