### PR TITLE
Cart Shipping Address and Method Fixes

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Cart/ExtractDataFromAddress.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/ExtractDataFromAddress.php
@@ -41,6 +41,7 @@ class ExtractDataFromAddress
         $addressData['model'] = $address;
 
         $addressData = array_merge($addressData, [
+            'address_id' => $address->getId(),
             'country' => [
                 'code' => $address->getCountryId(),
                 'label' => $address->getCountry()

--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/SetShippingMethodsOnCart.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/SetShippingMethodsOnCart.php
@@ -72,10 +72,10 @@ class SetShippingMethodsOnCart implements ResolverInterface
         if (!$shippingMethod['cart_address_id']) {
             throw new GraphQlInputException(__('Required parameter "cart_address_id" is missing'));
         }
-        if (!$shippingMethod['shipping_carrier_code']) {
+        if (!$shippingMethod['carrier_code']) {
             throw new GraphQlInputException(__('Required parameter "shipping_carrier_code" is missing'));
         }
-        if (!$shippingMethod['shipping_method_code']) {
+        if (!$shippingMethod['method_code']) {
             throw new GraphQlInputException(__('Required parameter "shipping_method_code" is missing'));
         }
 
@@ -85,8 +85,8 @@ class SetShippingMethodsOnCart implements ResolverInterface
         $this->setShippingMethodOnCart->execute(
             $cart,
             $shippingMethod['cart_address_id'],
-            $shippingMethod['shipping_carrier_code'],
-            $shippingMethod['shipping_method_code']
+            $shippingMethod['carrier_code'],
+            $shippingMethod['method_code']
         );
 
         return [

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -128,6 +128,7 @@ type Cart {
 }
 
 type CartAddress {
+    address_id: Int
     firstname: String
     lastname: String
     company: String


### PR DESCRIPTION
### Description (*)
* Makes cart address id available for shipping addresses (this is required for setting shipping methods)
* Corrects validation in `SetShippingMethodsOnCart` resolver to match schema updates https://github.com/magento/graphql-ce/commit/fa5613bb8ef5d85fdb75a70854f0caf69e58c4fd#diff-795a33fde881f18aba5165a5a8c7513fL68

### Manual testing scenarios (*)
1. Create quote and set shipping address
2. Query cart requesting shipping address id
```graphql
query getCart($cartId:String!){
  cart(cart_id:$cartId){
    cart_id
    shipping_addresses{
      address_id
    }
  }
}
```
3. Set shipping method for returned shipping address(es)
```graphql
mutation setShippingMethod($cartId:String!, $addressId:Int!){
  setShippingMethodsOnCart(
    input:{
      cart_id:$cartId
      shipping_methods:[
        {
          cart_address_id:$addressId
          carrier_code:"flatrate"
          method_code:"flatrate"
        }
      ]
    }
  ) {
    cart{
      items{
        id
      }
    }
  }
}
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
