### PR TITLE
Implement updates all properties in updateCustomer mutation

### DIFF
--- a/app/code/Magento/CustomerGraphQl/Model/Customer/UpdateCustomerData.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/UpdateCustomerData.php
@@ -19,6 +19,8 @@ use Magento\Store\Model\StoreManagerInterface;
  */
 class UpdateCustomerData
 {
+    private const RESTRICTED_DATA_KEYS = ['email', 'password'];
+
     /**
      * @var CustomerRepositoryInterface
      */
@@ -62,13 +64,14 @@ class UpdateCustomerData
     public function execute(int $customerId, array $data): void
     {
         $customer = $this->customerRepository->getById($customerId);
+        $newCustomerData = array_diff_key($data, array_flip(static::RESTRICTED_DATA_KEYS));
 
-        if (isset($data['firstname'])) {
-            $customer->setFirstname($data['firstname']);
-        }
-
-        if (isset($data['lastname'])) {
-            $customer->setLastname($data['lastname']);
+        foreach ($newCustomerData as $key => $value) {
+            $setterMethod = 'set' . ucwords($key, '_');
+            if (!method_exists($customer, $setterMethod)) {
+                continue;
+            }
+            $customer->{$setterMethod}($value);
         }
 
         if (isset($data['email']) && $customer->getEmail() !== $data['email']) {

--- a/app/code/Magento/CustomerGraphQl/etc/graphql/di.xml
+++ b/app/code/Magento/CustomerGraphQl/etc/graphql/di.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\CustomerGraphQl\Model\Customer\UpdateCustomerData">
+        <arguments>
+            <argument name="restrictedKeys" xsi:type="array">
+                <item name="email" xsi:type="const">Magento\Customer\Api\Data\CustomerInterface::EMAIL</item>
+            </argument>
+        </arguments>
+    </type>
+</config>

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerTest.php
@@ -47,23 +47,39 @@ class UpdateCustomerTest extends GraphQlAbstract
         $currentEmail = 'customer@example.com';
         $currentPassword = 'password';
 
+        $newPrefix = 'Dr';
         $newFirstname = 'Richard';
+        $newMiddlename = 'Riley';
         $newLastname = 'Rowe';
+        $newSuffix = 'III';
+        $newDob = '3/11/1972';
+        $newTaxVat = 'GQL1234567';
+        $newGender = 2;
         $newEmail = 'customer_updated@example.com';
 
         $query = <<<QUERY
 mutation {
     updateCustomer(
         input: {
+            prefix: "{$newPrefix}"
             firstname: "{$newFirstname}"
+            middlename: "{$newMiddlename}"
             lastname: "{$newLastname}"
+            suffix: "{$newSuffix}"
+            dob: "{$newDob}"
+            taxvat: "{$newTaxVat}"
             email: "{$newEmail}"
             password: "{$currentPassword}"
         }
     ) {
         customer {
+            prefix
             firstname
+            middlename
             lastname
+            suffix
+            dob
+            taxvat
             email
         }
     }
@@ -71,8 +87,14 @@ mutation {
 QUERY;
         $response = $this->graphQlQuery($query, [], '', $this->getCustomerAuthHeaders($currentEmail, $currentPassword));
 
+        $this->assertEquals($newPrefix, $response['updateCustomer']['customer']['prefix']);
         $this->assertEquals($newFirstname, $response['updateCustomer']['customer']['firstname']);
+        $this->assertEquals($newMiddlename, $response['updateCustomer']['customer']['middlename']);
         $this->assertEquals($newLastname, $response['updateCustomer']['customer']['lastname']);
+        $this->assertEquals($newSuffix, $response['updateCustomer']['customer']['suffix']);
+        $newDobDate = new \DateTime($newDob);
+        $this->assertEquals($newDobDate->format('Y-m-d'), $response['updateCustomer']['customer']['dob']);
+        $this->assertEquals($newTaxVat, $response['updateCustomer']['customer']['taxvat']);
         $this->assertEquals($newEmail, $response['updateCustomer']['customer']['email']);
     }
 


### PR DESCRIPTION
### Description (*)
The current schema defines properties that were ignored when processing user
input.

### Fixed Issues (if relevant)
1. magento/graphql-ce#388: updateCustomer mutation doesn't update undefined fields

### Manual testing scenarios (*)
1. Create customer
```graphql
mutation {
    createCustomer(
        input: {
            firstname: "Melanie"
            lastname: "Shaw"
            email: "mshaw@example.com"
            password: "Password1"
        }
    ) {
        customer {
            id
            firstname
            lastname
            email
        }
    }
}
```
2. Generate customer token required for update mutation
3. Update customer information
```graphql
mutation {
    updateCustomer(
        input: {
            prefix: "Dr"
            middlename: "Jessica"
            suffix: "Esq"
            dob: "3/11/1972"
            taxvat: "sometaxvat"
        }
    ) {
        customer {
            prefix
            firstname
            middlename
            lastname
            suffix
            dob
            taxvat
        }
    }
}
```
4. Validate all properties updated as requested

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
