### PR TITLE
address_type is null after setting billing and shipping addresses on cart

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Cart/ExtractDataFromAddress.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/ExtractDataFromAddress.php
@@ -42,6 +42,7 @@ class ExtractDataFromAddress
 
         $addressData = array_merge($addressData, [
             'address_id' => $address->getId(),
+            'address_type' => $address->getAddressType(),
             'country' => [
                 'code' => $address->getCountryId(),
                 'label' => $address->getCountry()

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -158,7 +158,7 @@ type CartAddress {
     postcode: String
     country: CartAddressCountry
     telephone: String
-    address_type: String
+    address_type: AdressTypeEnum
     available_shipping_methods: [AvailableShippingMethod] @resolver(class: "\\Magento\\QuoteGraphQl\\Model\\Resolver\\ShippingAdress\\AvailableShippingMethods")
     selected_shipping_method: SelectedShippingMethod
     items_weight: Float

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -158,7 +158,7 @@ type CartAddress {
     postcode: String
     country: CartAddressCountry
     telephone: String
-    address_type: AdressTypeEnum
+    address_type: String
     available_shipping_methods: [AvailableShippingMethod] @resolver(class: "\\Magento\\QuoteGraphQl\\Model\\Resolver\\ShippingAdress\\AvailableShippingMethods")
     selected_shipping_method: SelectedShippingMethod
     items_weight: Float
@@ -209,11 +209,6 @@ type SelectedPaymentMethod {
 }
 
 type SelectedPaymentMethodAdditionalData {
-}
-
-enum AdressTypeEnum {
-    SHIPPING
-    BILLING
 }
 
 type AppliedCoupon {

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -211,6 +211,11 @@ type SelectedPaymentMethod {
 type SelectedPaymentMethodAdditionalData {
 }
 
+enum AdressTypeEnum {
+    SHIPPING
+    BILLING
+}
+
 type AppliedCoupon {
     code: String!
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetBillingAddressOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetBillingAddressOnCartTest.php
@@ -90,6 +90,7 @@ mutation {
           code
           label
         }
+        address_type
       }
     }
   }
@@ -147,6 +148,7 @@ mutation {
           code
           label
         }
+        address_type
       }
       shipping_addresses {
         firstname
@@ -160,6 +162,7 @@ mutation {
           code
           label
         }
+        address_type
       }
     }
   }
@@ -174,7 +177,7 @@ QUERY;
         self::assertArrayHasKey('shipping_addresses', $cartResponse);
         $shippingAddressResponse = current($cartResponse['shipping_addresses']);
         $this->assertNewAddressFields($billingAddressResponse);
-        $this->assertNewAddressFields($shippingAddressResponse);
+        $this->assertNewAddressFields($shippingAddressResponse, 'shipping');
     }
 
     /**
@@ -403,9 +406,10 @@ QUERY;
     /**
      * Verify the all the whitelisted fields for a New Address Object
      *
-     * @param array $billingAddressResponse
+     * @param array $addressResponse
+     * @param string $addressType
      */
-    private function assertNewAddressFields(array $billingAddressResponse): void
+    private function assertNewAddressFields(array $addressResponse, string $addressType = 'billing'): void
     {
         $assertionMap = [
             ['response_field' => 'firstname', 'expected_value' => 'test firstname'],
@@ -416,9 +420,10 @@ QUERY;
             ['response_field' => 'postcode', 'expected_value' => '887766'],
             ['response_field' => 'telephone', 'expected_value' => '88776655'],
             ['response_field' => 'country', 'expected_value' => ['code' => 'US', 'label' => 'US']],
+            ['response_field' => 'address_type', 'expected_value' => $addressType]
         ];
 
-        $this->assertResponseFields($billingAddressResponse, $assertionMap);
+        $this->assertResponseFields($addressResponse, $assertionMap);
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetBillingAddressOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetBillingAddressOnCartTest.php
@@ -82,6 +82,7 @@ mutation {
           code
           label
         }
+        address_type
       }
     }
   }
@@ -138,6 +139,7 @@ mutation {
           code
           label
         }
+        address_type
       }
       shipping_addresses {
         firstname
@@ -151,6 +153,7 @@ mutation {
           code
           label
         }
+        address_type
       }
     }
   }
@@ -165,7 +168,7 @@ QUERY;
         self::assertArrayHasKey('shipping_addresses', $cartResponse);
         $shippingAddressResponse = current($cartResponse['shipping_addresses']);
         $this->assertNewAddressFields($billingAddressResponse);
-        $this->assertNewAddressFields($shippingAddressResponse);
+        $this->assertNewAddressFields($shippingAddressResponse, 'shipping');
     }
 
     /**
@@ -244,9 +247,10 @@ QUERY;
     /**
      * Verify the all the whitelisted fields for a New Address Object
      *
-     * @param array $billingAddressResponse
+     * @param array $addressResponse
+     * @param string $addressType
      */
-    private function assertNewAddressFields(array $billingAddressResponse): void
+    private function assertNewAddressFields(array $addressResponse, string $addressType = 'billing'): void
     {
         $assertionMap = [
             ['response_field' => 'firstname', 'expected_value' => 'test firstname'],
@@ -257,9 +261,10 @@ QUERY;
             ['response_field' => 'postcode', 'expected_value' => '887766'],
             ['response_field' => 'telephone', 'expected_value' => '88776655'],
             ['response_field' => 'country', 'expected_value' => ['code' => 'US', 'label' => 'US']],
+            ['response_field' => 'address_type', 'expected_value' => $addressType]
         ];
 
-        $this->assertResponseFields($billingAddressResponse, $assertionMap);
+        $this->assertResponseFields($addressResponse, $assertionMap);
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/SetShippingAddressOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/SetShippingAddressOnCartTest.php
@@ -94,6 +94,7 @@ mutation {
           code
           label
         }
+        address_type
       }
     }
   }
@@ -184,6 +185,7 @@ mutation {
           label
           code
         }
+        address_type
       }
     }
   }
@@ -472,6 +474,7 @@ QUERY;
             ['response_field' => 'postcode', 'expected_value' => '887766'],
             ['response_field' => 'telephone', 'expected_value' => '88776655'],
             ['response_field' => 'country', 'expected_value' => ['code' => 'US', 'label' => 'US']],
+            ['response_field' => 'address_type', 'expected_value' => 'shipping']
         ];
 
         $this->assertResponseFields($shippingAddressResponse, $assertionMap);


### PR DESCRIPTION

### Description (*)
Issue: https://github.com/magento/graphql-ce/issues/409

### Manual testing scenarios (*)
#### Preconditions (*)
1. Customer is created
2. Simple Product is created

#### Steps to reproduce (*)
1. Generate Customer token (GraphQL)
2. Create empty cart (GraphQL)
3. Add Simple Product to Cart (GraphQL)
4. Set shipping address on cart (GraphQL)
5. Set billing address on cart (GraphQL)
6. Perform query

```
query {
  cart(
    cart_id: "{{ CART_ID }}"
  ) {
    available_payment_methods {
      title
      code
    }
    billing_address {
      address_type
      available_shipping_methods {
        carrier_code
        method_code
      }
    }
    shipping_addresses {
      address_type
      available_shipping_methods {
        carrier_code
        method_code
        amount
      }
    }
  }
}
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
