### PR TITLE
Cannot return null for non-nullable field SelectedShippingMethod.amount

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Cart/ExtractDataFromAddress.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/ExtractDataFromAddress.php
@@ -55,6 +55,7 @@ class ExtractDataFromAddress
                 'code' => $address->getShippingMethod(),
                 'label' => $address->getShippingDescription(),
                 'free_shipping' => $address->getFreeShipping(),
+                'amount' => $address->getShippingAmount()
             ],
             'items_weight' => $address->getWeight(),
             'customer_notes' => $address->getCustomerNotes()


### PR DESCRIPTION
### Description (*)
Issue   https://github.com/magento/graphql-ce/issues/402

### Manual testing scenarios (*)

#### Preconditions (*)
1. Registered Customer
2. Simple Product
3. Virtual Product
4. Developer mode

#### Steps to reproduce (*)
1. Generate Customer token
2. Create empty cart as Registered Customer from GraphQL Client
3. Add simple and virtual products to cart from GraphQL Client but use

```
...
    cart {
      items {
        id
        __typename
...
```
in output
4. Get `ADDRESS_ID` by hovering 'Change Billing Address' or 'Change Shipping Address'
5. Set

```
mutation {
  setShippingAddressesOnCart(
    input: {
      cart_id: "{{ CART_ID }}"
      shipping_addresses: {
        customer_address_id: 3
        cart_items: [{
          cart_item_id: 11
          quantity: 1
        }
        {
          cart_item_id: 12
          quantity: 1
        }]
      }
    }
  ) {
    cart {
      cart_id
      shipping_addresses {
        address_type
        available_shipping_methods {
          carrier_code
          carrier_title
          method_code
          method_title
          price_excl_tax
          price_incl_tax
        }
        selected_shipping_method {
          amount
        }
      }
    }
  }
}
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
