### PR TITLE
429 - Test coverage: nonExistentCart

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetBillingAddressOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetBillingAddressOnCartTest.php
@@ -411,30 +411,16 @@ QUERY;
     public function testSetBillingAddressOnNonExistentCart()
     {
         $maskedQuoteId = 'non_existent_masked_id';
-        $query = $this->getCartQuery($maskedQuoteId);
-        $this->graphQlQuery($query, [], '', $this->getHeaderMap());
-    }
-
-    /**
-     * @param string $maskedQuoteId
-     * @return string
-     */
-    private function getCartQuery(
-        string $maskedQuoteId
-    ) : string {
-        return <<<QUERY
+        $query = <<<QUERY
 {
   cart(cart_id: "$maskedQuoteId") {
     items {
       id
-      qty
-      product {
-        sku
-      }
     }
   }
 }
 QUERY;
+        $this->graphQlQuery($query, [], '', $this->getHeaderMap());
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetBillingAddressOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetBillingAddressOnCartTest.php
@@ -404,6 +404,40 @@ QUERY;
     }
 
     /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @expectedException \Exception
+     * @expectedExceptionMessage Could not find a cart with ID "non_existent_masked_id"
+     */
+    public function testSetBillingAddressOnNonExistentCart()
+    {
+        $maskedQuoteId = 'non_existent_masked_id';
+        $query = $this->getCartQuery($maskedQuoteId);
+        $this->graphQlQuery($query, [], '', $this->getHeaderMap());
+    }
+
+    /**
+     * @param string $maskedQuoteId
+     * @return string
+     */
+    private function getCartQuery(
+        string $maskedQuoteId
+    ) : string {
+        return <<<QUERY
+{
+  cart(cart_id: "$maskedQuoteId") {
+    items {
+      id
+      qty
+      product {
+        sku
+      }
+    }
+  }
+}
+QUERY;
+    }
+
+    /**
      * Verify the all the whitelisted fields for a New Address Object
      *
      * @param array $addressResponse

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetPaymentMethodOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetPaymentMethodOnCartTest.php
@@ -159,30 +159,16 @@ class SetPaymentMethodOnCartTest extends GraphQlAbstract
     public function testPaymentMethodOnNonExistentCart()
     {
         $maskedQuoteId = 'non_existent_masked_id';
-        $query = $this->getCartQuery($maskedQuoteId);
-        $this->graphQlQuery($query, [], '', $this->getHeaderMap());
-    }
-
-    /**
-     * @param string $maskedQuoteId
-     * @return string
-     */
-    private function getCartQuery(
-        string $maskedQuoteId
-    ) : string {
-        return <<<QUERY
+        $query = <<<QUERY
 {
   cart(cart_id: "$maskedQuoteId") {
     items {
       id
-      qty
-      product {
-        sku
-      }
     }
   }
 }
 QUERY;
+        $this->graphQlQuery($query, [], '', $this->getHeaderMap());
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetPaymentMethodOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetPaymentMethodOnCartTest.php
@@ -152,6 +152,40 @@ class SetPaymentMethodOnCartTest extends GraphQlAbstract
     }
 
     /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @expectedException \Exception
+     * @expectedExceptionMessage Could not find a cart with ID "non_existent_masked_id"
+     */
+    public function testPaymentMethodOnNonExistentCart()
+    {
+        $maskedQuoteId = 'non_existent_masked_id';
+        $query = $this->getCartQuery($maskedQuoteId);
+        $this->graphQlQuery($query, [], '', $this->getHeaderMap());
+    }
+
+    /**
+     * @param string $maskedQuoteId
+     * @return string
+     */
+    private function getCartQuery(
+        string $maskedQuoteId
+    ) : string {
+        return <<<QUERY
+{
+  cart(cart_id: "$maskedQuoteId") {
+    items {
+      id
+      qty
+      product {
+        sku
+      }
+    }
+  }
+}
+QUERY;
+    }
+
+    /**
      * @param string $maskedQuoteId
      * @param string $methodCode
      * @return string

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetBillingAddressOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetBillingAddressOnCartTest.php
@@ -251,30 +251,16 @@ QUERY;
     public function testSetBillingAddressOnNonExistentCart()
     {
         $maskedQuoteId = 'non_existent_masked_id';
-        $query = $this->getCartQuery($maskedQuoteId);
-        $this->graphQlQuery($query);
-    }
-
-    /**
-     * @param string $maskedQuoteId
-     * @return string
-     */
-    private function getCartQuery(
-        string $maskedQuoteId
-    ) : string {
-        return <<<QUERY
+        $query = <<<QUERY
 {
   cart(cart_id: "$maskedQuoteId") {
     items {
       id
-      qty
-      product {
-        sku
-      }
     }
   }
 }
 QUERY;
+        $this->graphQlQuery($query);
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetBillingAddressOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetBillingAddressOnCartTest.php
@@ -245,6 +245,39 @@ QUERY;
     }
 
     /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Could not find a cart with ID "non_existent_masked_id"
+     */
+    public function testSetBillingAddressOnNonExistentCart()
+    {
+        $maskedQuoteId = 'non_existent_masked_id';
+        $query = $this->getCartQuery($maskedQuoteId);
+        $this->graphQlQuery($query);
+    }
+
+    /**
+     * @param string $maskedQuoteId
+     * @return string
+     */
+    private function getCartQuery(
+        string $maskedQuoteId
+    ) : string {
+        return <<<QUERY
+{
+  cart(cart_id: "$maskedQuoteId") {
+    items {
+      id
+      qty
+      product {
+        sku
+      }
+    }
+  }
+}
+QUERY;
+    }
+
+    /**
      * Verify the all the whitelisted fields for a New Address Object
      *
      * @param array $addressResponse

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetPaymentMethodOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetPaymentMethodOnCartTest.php
@@ -127,6 +127,17 @@ class SetPaymentMethodOnCartTest extends GraphQlAbstract
     }
 
     /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Could not find a cart with ID "non_existent_masked_id"
+     */
+    public function testSetPaymentOnNonExistentCart()
+    {
+        $maskedQuoteId = 'non_existent_masked_id';
+        $query = $this->getCartQuery($maskedQuoteId);
+        $this->graphQlQuery($query);
+    }
+
+    /**
      * @param string $maskedQuoteId
      * @param string $methodCode
      * @return string
@@ -148,6 +159,28 @@ mutation {
     cart {
       selected_payment_method {
         code
+      }
+    }
+  }
+}
+QUERY;
+    }
+
+    /**
+     * @param string $maskedQuoteId
+     * @return string
+     */
+    private function getCartQuery(
+        string $maskedQuoteId
+    ) : string {
+        return <<<QUERY
+{
+  cart(cart_id: "$maskedQuoteId") {
+    items {
+      id
+      qty
+      product {
+        sku
       }
     }
   }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetPaymentMethodOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetPaymentMethodOnCartTest.php
@@ -133,7 +133,15 @@ class SetPaymentMethodOnCartTest extends GraphQlAbstract
     public function testSetPaymentOnNonExistentCart()
     {
         $maskedQuoteId = 'non_existent_masked_id';
-        $query = $this->getCartQuery($maskedQuoteId);
+        $query = <<<QUERY
+{
+  cart(cart_id: "$maskedQuoteId") {
+    items {
+      id
+    }
+  }
+}
+QUERY;
         $this->graphQlQuery($query);
     }
 
@@ -159,28 +167,6 @@ mutation {
     cart {
       selected_payment_method {
         code
-      }
-    }
-  }
-}
-QUERY;
-    }
-
-    /**
-     * @param string $maskedQuoteId
-     * @return string
-     */
-    private function getCartQuery(
-        string $maskedQuoteId
-    ) : string {
-        return <<<QUERY
-{
-  cart(cart_id: "$maskedQuoteId") {
-    items {
-      id
-      qty
-      product {
-        sku
       }
     }
   }


### PR DESCRIPTION
**Test coverage: nonExistentCart #429**
1. Add none existing cart test to
- \Magento\GraphQl\Quote\Customer\SetPaymentMethodOnCartTest
- \Magento\GraphQl\Quote\Guest\SetPaymentMethodOnCartTest
- \Magento\GraphQl\Quote\Customer\SetBillingAddressOnCartTest
- \Magento\GraphQl\Quote\Guest\SetBillingAddressOnCartTest
