### PR TITLE
419 test coverage get available payment methods customer

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetAvailablePaymentMethodsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetAvailablePaymentMethodsTest.php
@@ -85,6 +85,18 @@ class GetAvailablePaymentMethodsTest extends GraphQlAbstract
         $this->graphQlQuery($query, [], '', $this->getHeaderMap('customer3@search.example.com'));
     }
 
+    /**
+     * @magentoApiDataFixture Magento/Checkout/_files/quote_with_items_saved.php
+     * @magentoApiDataFixture Magento/Payment/_files/disable_all_active_payment_methods.php
+     */
+    public function testGetPaymentMethodsIfPaymentsAreNotSet()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId('test_order_item_with_items');
+        $query         = $this->getCartAvailablePaymentMethodsQuery($maskedQuoteId);
+        $response      = $this->graphQlQuery($query, [], '', $this->getHeaderMap());
+
+        self::assertEquals(0, count($response['cart']['available_payment_methods']));
+    }
 
     /**
      * @magentoApiDataFixture Magento/Customer/_files/customer.php

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetAvailablePaymentMethodsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetAvailablePaymentMethodsTest.php
@@ -134,8 +134,7 @@ class GetAvailablePaymentMethodsTest extends GraphQlAbstract
      */
     private function getQuery(
         string $maskedQuoteId
-    ): string
-    {
+    ): string {
         return <<<QUERY
 {
   cart(cart_id: "$maskedQuoteId") {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetCartTest.php
@@ -72,8 +72,8 @@ class GetCartTest extends GraphQlAbstract
     }
 
     /**
-     * @magentoApiDataFixture Magento/Checkout/_files/quote_with_simple_product_saved.php
      * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/Checkout/_files/quote_with_simple_product_saved.php
      */
     public function testGetGuestCart()
     {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/RemoveItemFromCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/RemoveItemFromCartTest.php
@@ -129,7 +129,7 @@ class RemoveItemFromCartTest extends GraphQlAbstract
     }
 
     /**
-     * @magentoApiDataFixture Magento/Checkout/_files/quote_with_address_saved.php
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
      * @magentoApiDataFixture Magento/Checkout/_files/quote_with_virtual_product_saved.php
      */
     public function testRemoveItemFromGuestCart()

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/UpdateCartItemsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/UpdateCartItemsTest.php
@@ -156,7 +156,7 @@ class UpdateCartItemsTest extends GraphQlAbstract
     }
 
     /**
-     * @magentoApiDataFixture Magento/Checkout/_files/quote_with_address_saved.php
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
      * @magentoApiDataFixture Magento/Checkout/_files/quote_with_virtual_product_saved.php
      */
     public function testUpdateItemInGuestCart()

--- a/dev/tests/integration/testsuite/Magento/Payment/_files/disable_all_active_payment_methods.php
+++ b/dev/tests/integration/testsuite/Magento/Payment/_files/disable_all_active_payment_methods.php
@@ -7,23 +7,17 @@ declare(strict_types=1);
 
 use Magento\Config\Model\Config;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\Store;
 use Magento\TestFramework\Helper\Bootstrap;
 
-$processConfigData = function (Config $config, array $data) {
-    foreach ($data as $key => $value) {
-        $config->setDataByPath($key, $value);
-        $config->save();
-    }
-};
-
-$objectManager          = Bootstrap::getObjectManager();
-$paymentMethodList      = $objectManager->get(\Magento\Payment\Api\PaymentMethodListInterface::class);
-$rollbackConfigKey      = 'test/payment/disabled_payment_methods';
-$configData             = [];
+$objectManager = Bootstrap::getObjectManager();
+$paymentMethodList = $objectManager->get(\Magento\Payment\Api\PaymentMethodListInterface::class);
+$rollbackConfigKey = 'test/payment/disabled_payment_methods';
+$configData = [];
 $disabledPaymentMethods = [];
 
 // Get all active Payment Methods
-foreach ($paymentMethodList->getActiveList(\Magento\Store\Model\Store::DEFAULT_STORE_ID) as $paymentMethod) {
+foreach ($paymentMethodList->getActiveList(Store::DEFAULT_STORE_ID) as $paymentMethod) {
     $configData['payment/' . $paymentMethod->getCode() . '/active'] = 0;
     $disabledPaymentMethods[] = $paymentMethod->getCode();
 }
@@ -34,4 +28,8 @@ $configData[$rollbackConfigKey] = implode(',', $disabledPaymentMethods);
 $defConfig = $objectManager->create(Config::class);
 $defConfig->setScope(ScopeConfigInterface::SCOPE_TYPE_DEFAULT);
 
-$processConfigData($defConfig, $configData);
+foreach ($configData as $key => $value) {
+    $defConfig->setDataByPath($key, $value);
+    $defConfig->save();
+}
+

--- a/dev/tests/integration/testsuite/Magento/Payment/_files/disable_all_active_payment_methods.php
+++ b/dev/tests/integration/testsuite/Magento/Payment/_files/disable_all_active_payment_methods.php
@@ -32,4 +32,3 @@ foreach ($configData as $key => $value) {
     $defConfig->setDataByPath($key, $value);
     $defConfig->save();
 }
-

--- a/dev/tests/integration/testsuite/Magento/Payment/_files/disable_all_active_payment_methods.php
+++ b/dev/tests/integration/testsuite/Magento/Payment/_files/disable_all_active_payment_methods.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Config\Model\Config;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+$processConfigData = function (Config $config, array $data) {
+    foreach ($data as $key => $value) {
+        $config->setDataByPath($key, $value);
+        $config->save();
+    }
+};
+
+$objectManager          = Bootstrap::getObjectManager();
+$paymentMethodList      = $objectManager->get(\Magento\Payment\Api\PaymentMethodListInterface::class);
+$rollbackConfigKey      = 'test/payment/disabled_payment_methods';
+$configData             = [];
+$disabledPaymentMethods = [];
+
+// Get all active Payment Methods
+foreach ($paymentMethodList->getActiveList(\Magento\Store\Model\Store::DEFAULT_STORE_ID) as $paymentMethod) {
+    $configData['payment/' . $paymentMethod->getCode() . '/active'] = 0;
+    $disabledPaymentMethods[] = $paymentMethod->getCode();
+}
+// Remember all manually disabled Payment Methods for rollback
+$configData[$rollbackConfigKey] = implode(',', $disabledPaymentMethods);
+
+/** @var Config $defConfig */
+$defConfig = $objectManager->create(Config::class);
+$defConfig->setScope(ScopeConfigInterface::SCOPE_TYPE_DEFAULT);
+
+$processConfigData($defConfig, $configData);

--- a/dev/tests/integration/testsuite/Magento/Payment/_files/disable_all_active_payment_methods_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Payment/_files/disable_all_active_payment_methods_rollback.php
@@ -9,10 +9,10 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 
-$objectManager     = Bootstrap::getObjectManager();
+$objectManager = Bootstrap::getObjectManager();
 $rollbackConfigKey = 'test/payment/disabled_payment_methods';
 
-$configWriter        = $objectManager->create(WriterInterface::class);
+$configWriter = $objectManager->create(WriterInterface::class);
 $rollbackConfigValue = $objectManager->get(\Magento\Store\Model\StoreManagerInterface::class)
     ->getStore(\Magento\Store\Model\Store::DEFAULT_STORE_ID)
     ->getConfig($rollbackConfigKey);

--- a/dev/tests/integration/testsuite/Magento/Payment/_files/disable_all_active_payment_methods_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Payment/_files/disable_all_active_payment_methods_rollback.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+$objectManager     = Bootstrap::getObjectManager();
+$rollbackConfigKey = 'test/payment/disabled_payment_methods';
+
+$configWriter        = $objectManager->create(WriterInterface::class);
+$rollbackConfigValue = $objectManager->get(\Magento\Store\Model\StoreManagerInterface::class)
+    ->getStore(\Magento\Store\Model\Store::DEFAULT_STORE_ID)
+    ->getConfig($rollbackConfigKey);
+
+$disabledPaymentMethods = [];
+if (!empty($rollbackConfigValue)) {
+    $disabledPaymentMethods = explode(',', $rollbackConfigValue);
+}
+
+if (count($disabledPaymentMethods)) {
+    foreach ($disabledPaymentMethods as $keyToRemove) {
+        $configWriter->delete(sprintf('payment/%s/active', $keyToRemove));
+    }
+}
+$configWriter->delete($rollbackConfigKey);
+
+$scopeConfig = $objectManager->get(ScopeConfigInterface::class);
+$scopeConfig->clean();


### PR DESCRIPTION
**Test coverage: GetAvailablePaymentMethodsTest for Customer #419**

Pull request covers next cases:
- testGetPaymentMethodsFromCustomerCart (get available payment methods for the customer's shopping cart)
- testGetPaymentMethodsFromAnotherCustomerCart (get available payment methods from the shopping cart of another customer)
- testGetPaymentMethodsIfPaymentsAreNotSet (check available payment methods when all payment methods are disabled)
- testGetPaymentMethodsOfNonExistentCart (shopping cart does not exist)

*Issue:* https://github.com/magento/graphql-ce/issues/419