### PR TITLE
Skip failing ProductViewTest::testProductPrices

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductViewTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductViewTest.php
@@ -583,6 +583,8 @@ QUERY;
      */
     public function testProductPrices()
     {
+        $this->markTestSkipped("https://github.com/magento/graphql-ce/issues/453");
+
         $firstProductSku = 'simple-249';
         $secondProductSku = 'simple-156';
         $query = <<<QUERY


### PR DESCRIPTION
### Description (*)
This Pull Request skips `\Magento\GraphQl\Catalog\ProductViewTest::testProductPrices` which fails on the Magento installations containing latest version of MSI.

Appropriate ticket to get it fixed was created: https://github.com/magento/graphql-ce/issues/453

### Fixed Issues (if relevant)
1. N/A

### Manual testing scenarios (*)
1. N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
