### PR TITLE
graphQl-430: added testReSetPaymentMethod for guest and customer

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetPaymentMethodOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetPaymentMethodOnCartTest.php
@@ -172,6 +172,23 @@ QUERY;
     }
 
     /**
+     * @magentoApiDataFixture Magento/Checkout/_files/quote_with_payment_saved.php
+     */
+    public function testReSetPayment()
+    {
+        /** @var \Magento\Quote\Model\Quote  $quote */
+        $maskedQuoteId = $this->getMaskedQuoteIdByReversedQuoteId('test_order_1_with_payment');
+        $methodCode = Checkmo::PAYMENT_METHOD_CHECKMO_CODE;
+        $query = $this->prepareMutationQuery($maskedQuoteId, $methodCode);
+        $response = $this->graphQlQuery($query, [], '', $this->getHeaderMap());
+
+        self::assertArrayHasKey('setPaymentMethodOnCart', $response);
+        self::assertArrayHasKey('cart', $response['setPaymentMethodOnCart']);
+        self::assertArrayHasKey('selected_payment_method', $response['setPaymentMethodOnCart']['cart']);
+        self::assertEquals($methodCode, $response['setPaymentMethodOnCart']['cart']['selected_payment_method']['code']);
+    }
+
+    /**
      * @param string $maskedQuoteId
      * @param string $methodCode
      * @return string

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetPaymentMethodOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetPaymentMethodOnCartTest.php
@@ -146,6 +146,24 @@ QUERY;
     }
 
     /**
+     * @magentoApiDataFixture Magento/Checkout/_files/quote_with_payment_saved.php
+     */
+    public function testReSetPayment()
+    {
+        /** @var \Magento\Quote\Model\Quote  $quote */
+        $maskedQuoteId = $this->getMaskedQuoteIdByReversedQuoteId('test_order_1_with_payment');
+        $this->unAssignCustomerFromQuote('test_order_1_with_payment');
+        $methodCode = Checkmo::PAYMENT_METHOD_CHECKMO_CODE;
+        $query = $this->prepareMutationQuery($maskedQuoteId, $methodCode);
+        $response = $this->graphQlQuery($query);
+
+        self::assertArrayHasKey('setPaymentMethodOnCart', $response);
+        self::assertArrayHasKey('cart', $response['setPaymentMethodOnCart']);
+        self::assertArrayHasKey('selected_payment_method', $response['setPaymentMethodOnCart']['cart']);
+        self::assertEquals($methodCode, $response['setPaymentMethodOnCart']['cart']['selected_payment_method']['code']);
+    }
+
+    /**
      * @param string $maskedQuoteId
      * @param string $methodCode
      * @return string


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento/graphql-ce#430: Test coverage: testReSetPaymentMethod

