### PR TITLE
While adding the product to Cart when the requested Qty is zero or less then zero, one was unexpectedly added

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Cart/AddSimpleProductToCart.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/AddSimpleProductToCart.php
@@ -67,6 +67,11 @@ class AddSimpleProductToCart
     {
         $sku = $this->extractSku($cartItemData);
         $qty = $this->extractQty($cartItemData);
+        if ($qty <= 0) {
+            throw new GraphQlInputException(
+                __('Please enter a number greater than 0 in this field.')
+            );
+        }
         $customizableOptions = $this->extractCustomizableOptions($cartItemData);
 
         try {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/AddSimpleProductToCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/AddSimpleProductToCartTest.php
@@ -60,6 +60,22 @@ class AddSimpleProductToCartTest extends GraphQlAbstract
     }
 
     /**
+     * @magentoApiDataFixture Magento/Catalog/_files/products.php
+     * @magentoApiDataFixture Magento/Checkout/_files/active_quote.php
+     * @expectedException \Exception
+     * @expectedExceptionMessage Please enter a number greater than 0 in this field.
+     */
+    public function testAddSimpleProductToCartWithNegativeQty()
+    {
+        $sku = 'simple';
+        $qty = -2;
+        $maskedQuoteId = $this->getMaskedQuoteId();
+
+        $query = $this->getAddSimpleProductQuery($maskedQuoteId, $sku, $qty);
+        $this->graphQlQuery($query);
+    }
+
+    /**
      * @return string
      */
     public function getMaskedQuoteId() : string


### PR DESCRIPTION
### Description (*)
Issue https://github.com/magento/graphql-ce/issues/357

### Manual testing scenarios (*)

Create any Product from Storefront with qty 1000 and Stock Status IN_STOCK
Create an empty Cart from Storefront or using GraphQL API.
Get the Masked Quote Id
Perform GraphQL mutation addSimpleProductToCart




### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
