### PR TITLE
[+] added tests for SetPaymentMethodOnCart functionality

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/SetPaymentMethodOnCart.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/SetPaymentMethodOnCart.php
@@ -60,12 +60,12 @@ class SetPaymentMethodOnCart implements ResolverInterface
     public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
     {
         if (!isset($args['input']['cart_id']) || empty($args['input']['cart_id'])) {
-            throw new GraphQlInputException(__('Required parameter "cart_id" is missing'));
+            throw new GraphQlInputException(__('Required parameter "cart_id" is missing.'));
         }
         $maskedCartId = $args['input']['cart_id'];
 
         if (!isset($args['input']['payment_method']['code']) || empty($args['input']['payment_method']['code'])) {
-            throw new GraphQlInputException(__('Required parameter "payment_method" is missing'));
+            throw new GraphQlInputException(__('Required parameter "code" for "payment_method" is missing.'));
         }
         $paymentMethodCode = $args['input']['payment_method']['code'];
 

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetPaymentMethodOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetPaymentMethodOnCartTest.php
@@ -172,6 +172,54 @@ QUERY;
     }
 
     /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/Checkout/_files/quote_with_address_saved.php
+     * @param string $input
+     * @param string $message
+     * @dataProvider dataProviderSetPaymentMethodWithoutRequiredParameters
+     */
+    public function testSetPaymentMethodWithoutRequiredParameters(string $input, string $message)
+    {
+        $query = <<<QUERY
+mutation {
+  setPaymentMethodOnCart(
+    input: {
+      {$input}
+    }
+  ) {
+    cart {
+      items {
+        qty
+      }
+    }
+  }
+}
+QUERY;
+        $this->expectExceptionMessage($message);
+        $this->graphQlQuery($query, [], '', $this->getHeaderMap());
+    }
+    /**
+     * @return array
+     */
+    public function dataProviderSetPaymentMethodWithoutRequiredParameters(): array
+    {
+        return [
+            'missed_cart_id' => [
+                'payment_method: {code: "'.Checkmo::PAYMENT_METHOD_CHECKMO_CODE.'"}',
+                'Required parameter "cart_id" is missing.'
+            ],
+            'missed_payment_method' => [
+                'cart_id: "test"',
+                'Required parameter "code" for "payment_method" is missing.'
+            ],
+            'missed_payment_method_code' => [
+                'cart_id: "test",payment_method: {code: ""}',
+                'Required parameter "code" for "payment_method" is missing.'
+            ],
+        ];
+    }
+
+    /**
      * @magentoApiDataFixture Magento/Checkout/_files/quote_with_payment_saved.php
      */
     public function testReSetPayment()

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetPaymentMethodOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetPaymentMethodOnCartTest.php
@@ -205,7 +205,7 @@ QUERY;
     {
         return [
             'missed_cart_id' => [
-                'payment_method: {code: "'.Checkmo::PAYMENT_METHOD_CHECKMO_CODE.'"}',
+                'payment_method: {code: "' . Checkmo::PAYMENT_METHOD_CHECKMO_CODE . '"}',
                 'Required parameter "cart_id" is missing.'
             ],
             'missed_payment_method' => [
@@ -213,7 +213,7 @@ QUERY;
                 'Required parameter "code" for "payment_method" is missing.'
             ],
             'missed_payment_method_code' => [
-                'cart_id: "test",payment_method: {code: ""}',
+                'cart_id: "test", payment_method: {code: ""}',
                 'Required parameter "code" for "payment_method" is missing.'
             ],
         ];

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetPaymentMethodOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetPaymentMethodOnCartTest.php
@@ -127,6 +127,53 @@ class SetPaymentMethodOnCartTest extends GraphQlAbstract
     }
 
     /**
+     * @magentoApiDataFixture Magento/Checkout/_files/quote_with_address_saved.php
+     * @param string $input
+     * @param string $message
+     * @dataProvider dataProviderSetPaymentMethodWithoutRequiredParameters
+     */
+    public function testSetPaymentMethodWithoutRequiredParameters(string $input, string $message)
+    {
+        $query = <<<QUERY
+mutation {
+  setPaymentMethodOnCart(
+    input: {
+      {$input}
+    }
+  ) {
+    cart {
+      items {
+        qty
+      }
+    }
+  }
+}
+QUERY;
+        $this->expectExceptionMessage($message);
+        $this->graphQlQuery($query);
+    }
+    /**
+     * @return array
+     */
+    public function dataProviderSetPaymentMethodWithoutRequiredParameters(): array
+    {
+        return [
+            'missed_cart_id' => [
+                'payment_method: {code: "'.Checkmo::PAYMENT_METHOD_CHECKMO_CODE.'"}',
+                'Required parameter "cart_id" is missing.'
+            ],
+            'missed_payment_method' => [
+                'cart_id: "test"',
+                'Required parameter "code" for "payment_method" is missing.'
+            ],
+            'missed_payment_method_code' => [
+                'cart_id: "test",payment_method: {code: ""}',
+                'Required parameter "code" for "payment_method" is missing.'
+            ],
+        ];
+    }
+
+    /**
      * @expectedException \Exception
      * @expectedExceptionMessage Could not find a cart with ID "non_existent_masked_id"
      */

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetPaymentMethodOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetPaymentMethodOnCartTest.php
@@ -159,7 +159,7 @@ QUERY;
     {
         return [
             'missed_cart_id' => [
-                'payment_method: {code: "'.Checkmo::PAYMENT_METHOD_CHECKMO_CODE.'"}',
+                'payment_method: {code: "' . Checkmo::PAYMENT_METHOD_CHECKMO_CODE . '"}',
                 'Required parameter "cart_id" is missing.'
             ],
             'missed_payment_method' => [
@@ -167,7 +167,7 @@ QUERY;
                 'Required parameter "code" for "payment_method" is missing.'
             ],
             'missed_payment_method_code' => [
-                'cart_id: "test",payment_method: {code: ""}',
+                'cart_id: "test", payment_method: {code: ""}',
                 'Required parameter "code" for "payment_method" is missing.'
             ],
         ];


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Covered SetPaymentMethodOnCart functionality with API-functional tests.
Testcases:
\Magento\GraphQl\Quote\Customer\SetPaymentMethodOnCartTest
- testSetPaymentMethodWitoutRequiredParameters [missed cart_id, missed payment_method, missed payment_method[code]] 
\Magento\GraphQl\Quote\Guest\SetPaymentMethodOnCartTest
- testSetPaymentMethodWitoutRequiredParameters [missed cart_id, missed payment_method, payment_method[code]] 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/graphql-ce#483: [Test Coverage] 'SetPaymentMethodOnCart' functionality



### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
