### PR TITLE
graphQl-579: added test coverage for setting disabled shipping method

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetShippingMethodsOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetShippingMethodsOnCartTest.php
@@ -251,6 +251,14 @@ QUERY;
                 }]',
                 'Could not find a cart with ID "non_existent_masked_id"'
             ],
+            'disabled_shipping_method' => [
+                'cart_id: "cart_id_value", shipping_methods: [{
+                    cart_address_id: cart_address_id_value
+                    carrier_code: "freeshipping"
+                    method_code: "freeshipping"
+                }]',
+                'Carrier with such method not found: freeshipping, freeshipping'
+            ]
         ];
     }
 

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetShippingMethodsOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetShippingMethodsOnCartTest.php
@@ -270,6 +270,14 @@ QUERY;
                 }]',
                 'Could not find a cart with ID "non_existent_masked_id"'
             ],
+            'disabled_shipping_method' => [
+                'cart_id: "cart_id_value", shipping_methods: [{
+                    cart_address_id: cart_address_id_value
+                    carrier_code: "freeshipping"
+                    method_code: "freeshipping"
+                }]',
+                'Carrier with such method not found: freeshipping, freeshipping'
+            ],
         ];
     }
 


### PR DESCRIPTION
### Fixed Issues (if relevant)

1. #579: [Test Coverage] 'SetShippingMethodsOnCart' functionality
