### PR TITLE
#628 Check if email or password are empty (generateCustomerToken)

### DIFF
--- a/app/code/Magento/CustomerGraphQl/Model/Resolver/GenerateCustomerToken.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Resolver/GenerateCustomerToken.php
@@ -44,11 +44,11 @@ class GenerateCustomerToken implements ResolverInterface
         array $value = null,
         array $args = null
     ) {
-        if (!isset($args['email'])) {
+        if (!isset($args['email']) || empty($args['email'])) {
             throw new GraphQlInputException(__('Specify the "email" value.'));
         }
 
-        if (!isset($args['password'])) {
+        if (!isset($args['password']) || empty($args['password'])) {
             throw new GraphQlInputException(__('Specify the "password" value.'));
         }
 

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GenerateCustomerTokenTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GenerateCustomerTokenTest.php
@@ -68,4 +68,54 @@ MUTATION;
             'was incorrect or your account is disabled temporarily. Please wait and try again later.');
         $this->graphQlMutation($mutation);
     }
+
+    /**
+     * Verify customer with empty email
+     */
+    public function testGenerateCustomerTokenWithEmptyEmail()
+    {
+        $email = '';
+        $password = 'bad-password';
+
+        $mutation
+            = <<<MUTATION
+mutation {
+	generateCustomerToken(
+        email: "{$email}"
+        password: "{$password}"
+    ) {
+        token
+    }
+}
+MUTATION;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('GraphQL response contains errors: Specify the "email" value.');
+        $this->graphQlMutation($mutation);
+    }
+
+    /**
+     * Verify customer with empty password
+     */
+    public function testGenerateCustomerTokenWithEmptyPassword()
+    {
+        $email = 'customer@example.com';
+        $password = '';
+
+        $mutation
+            = <<<MUTATION
+mutation {
+	generateCustomerToken(
+        email: "{$email}"
+        password: "{$password}"
+    ) {
+        token
+    }
+}
+MUTATION;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('GraphQL response contains errors: Specify the "password" value.');
+        $this->graphQlMutation($mutation);
+    }
 }


### PR DESCRIPTION
Check in the mutation `generateCustomerToken` if params email or password are empty 

### Description (*)

Check in the mutation `generateCustomerToken` if params email or password are empty 

### Fixed Issues (if relevant)
1. magento/graphql-ce#628: Error message for mutation generateCustomerToken

### Manual testing scenarios (*)
1. Execute
query:
```graphql
mutation generateCustomerToken(
  $email: String!
  $password: String!
) {
  generateCustomerToken(
    email: $email
    password: $password
  ) {
    token
  }
}
```
variables:
```json
    {
        "email": "",
        "password": ""
    }
```
#### Result:
1. "message": "\"username\" is required. Enter and try again."
2. "message": "\"password\" is required. Enter and try again."

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
