### PR TITLE
graphQl-640: fixed input type declaration for PaymentMethodAdditional…

### DIFF
--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -130,11 +130,8 @@ input SetPaymentMethodOnCartInput {
 
 input PaymentMethodInput {
     code: String! @doc(description:"Payment method code")
-    additional_data: PaymentMethodAdditionalDataInput @doc(description:"Additional payment data")
     purchase_order_number: String @doc(description:"Purchase order number")
 }
-
-input PaymentMethodAdditionalDataInput
 
 input SetGuestEmailOnCartInput {
     cart_id: String!
@@ -257,11 +254,8 @@ type AvailablePaymentMethod {
 type SelectedPaymentMethod {
     code: String! @doc(description: "The payment method code")
     title: String! @doc(description: "The payment method title.")
-    additional_data: SelectedPaymentMethodAdditionalData @doc(description: "Additional payment data")
     purchase_order_number: String @doc(description: "The purchase order number.")
 }
-
-type SelectedPaymentMethodAdditionalData
 
 type AppliedCoupon {
     code: String!

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -134,8 +134,7 @@ input PaymentMethodInput {
     purchase_order_number: String @doc(description:"Purchase order number")
 }
 
-input PaymentMethodAdditionalDataInput {
-}
+input PaymentMethodAdditionalDataInput
 
 input SetGuestEmailOnCartInput {
     cart_id: String!
@@ -262,8 +261,7 @@ type SelectedPaymentMethod {
     purchase_order_number: String @doc(description: "The purchase order number.")
 }
 
-type SelectedPaymentMethodAdditionalData {
-}
+type SelectedPaymentMethodAdditionalData
 
 type AppliedCoupon {
     code: String!


### PR DESCRIPTION
### Description (*)
Removed {} (curly braces) from empty types in order to pass the syntax validation.

### Fixed Issues (if relevant)
1. #640: Input type declaration in GraphQL SDL cannot be empty
