### PR TITLE
GraphQl-535: provided catalog configs

### DIFF
--- a/app/code/Magento/CatalogGraphQl/etc/graphql/di.xml
+++ b/app/code/Magento/CatalogGraphQl/etc/graphql/di.xml
@@ -80,4 +80,26 @@
     </virtualType>
     <preference for="Magento\Framework\Search\Adapter\Mysql\Query\Builder\Match"
                 type="Magento\CatalogGraphQl\Model\Search\Adapter\Mysql\Query\Builder\Match" />
+    <type name="Magento\StoreGraphQl\Model\Resolver\Store\StoreConfigDataProvider">
+        <arguments>
+            <argument name="extendedConfigData" xsi:type="array">
+                <item name="product_url_suffix" xsi:type="string">catalog/seo/product_url_suffix</item>
+                <item name="category_url_suffix" xsi:type="string">catalog/seo/category_url_suffix</item>
+                <item name="product_use_categories" xsi:type="string">catalog/seo/product_use_categories</item>
+                <item name="save_rewrites_history" xsi:type="string">catalog/seo/save_rewrites_history</item>
+                <item name="title_separator" xsi:type="string">catalog/seo/title_separator</item>
+                <item name="category_canonical_tag" xsi:type="string">catalog/seo/category_canonical_tag</item>
+                <item name="product_canonical_tag" xsi:type="string">catalog/seo/product_canonical_tag</item>
+                <item name="list_mode" xsi:type="string">catalog/frontend/list_mode</item>
+                <item name="grid_per_page_values" xsi:type="string">catalog/frontend/grid_per_page_values</item>
+                <item name="list_per_page_values" xsi:type="string">catalog/frontend/list_per_page_values</item>
+                <item name="grid_per_page" xsi:type="string">catalog/frontend/grid_per_page</item>
+                <item name="list_per_page" xsi:type="string">catalog/frontend/list_per_page</item>
+                <item name="flat_catalog_category" xsi:type="string">catalog/frontend/flat_catalog_category</item>
+                <item name="catalog_default_sort_by" xsi:type="string">catalog/frontend/default_sort_by</item>
+                <item name="parse_url_directives" xsi:type="string">catalog/frontend/parse_url_directives</item>
+                <item name="remember_pagination" xsi:type="string">catalog/frontend/remember_pagination</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/CatalogGraphQl/etc/graphql/di.xml
+++ b/app/code/Magento/CatalogGraphQl/etc/graphql/di.xml
@@ -85,20 +85,13 @@
             <argument name="extendedConfigData" xsi:type="array">
                 <item name="product_url_suffix" xsi:type="string">catalog/seo/product_url_suffix</item>
                 <item name="category_url_suffix" xsi:type="string">catalog/seo/category_url_suffix</item>
-                <item name="product_use_categories" xsi:type="string">catalog/seo/product_use_categories</item>
-                <item name="save_rewrites_history" xsi:type="string">catalog/seo/save_rewrites_history</item>
                 <item name="title_separator" xsi:type="string">catalog/seo/title_separator</item>
-                <item name="category_canonical_tag" xsi:type="string">catalog/seo/category_canonical_tag</item>
-                <item name="product_canonical_tag" xsi:type="string">catalog/seo/product_canonical_tag</item>
                 <item name="list_mode" xsi:type="string">catalog/frontend/list_mode</item>
                 <item name="grid_per_page_values" xsi:type="string">catalog/frontend/grid_per_page_values</item>
                 <item name="list_per_page_values" xsi:type="string">catalog/frontend/list_per_page_values</item>
                 <item name="grid_per_page" xsi:type="string">catalog/frontend/grid_per_page</item>
                 <item name="list_per_page" xsi:type="string">catalog/frontend/list_per_page</item>
-                <item name="flat_catalog_category" xsi:type="string">catalog/frontend/flat_catalog_category</item>
                 <item name="catalog_default_sort_by" xsi:type="string">catalog/frontend/default_sort_by</item>
-                <item name="parse_url_directives" xsi:type="string">catalog/frontend/parse_url_directives</item>
-                <item name="remember_pagination" xsi:type="string">catalog/frontend/remember_pagination</item>
             </argument>
         </arguments>
     </type>

--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -405,18 +405,11 @@ type SortFields @doc(description: "SortFields contains a default value for sort 
 type StoreConfig @doc(description: "The type contains information about a store config") {
     product_url_suffix : String @doc(description: "Product URL Suffix")
     category_url_suffix : String @doc(description: "Category URL Suffix")
-    product_use_categories : Int @doc(description: "Use Categories Path for Product URLs")
-    save_rewrites_history : Int @doc(description: "Create Permanent Redirect for URLs if URL Key Changed")
     title_separator : String @doc(description: "Page Title Separator")
-    category_canonical_tag : Int @doc(description: "Use Canonical Link Meta Tag For Categories")
-    product_canonical_tag : Int @doc(description: "Use Canonical Link Meta Tag For Products")
     list_mode : String @doc(description: "List Mode")
     grid_per_page_values : String @doc(description: "Products per Page on Grid Allowed Values")
     list_per_page_values : String @doc(description: "Products per Page on List Allowed Values")
     grid_per_page : Int @doc(description: "Products per Page on Grid Default Value")
     list_per_page : Int @doc(description: "Products per Page on List Default Value")
-    flat_catalog_category : Int @doc(description: "Use Flat Catalog Category")
     catalog_default_sort_by : String @doc(description: "Default Sort By")
-    parse_url_directives : Int @doc(description: "Parse URL directives")
-    remember_pagination : Int @doc(description: "Remember Pagination")
 }

--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -401,3 +401,22 @@ type SortFields @doc(description: "SortFields contains a default value for sort 
     default: String @doc(description: "Default value of sort fields")
     options: [SortField] @doc(description: "Available sort fields")
 }
+
+type StoreConfig @doc(description: "The type contains information about a store config") {
+    product_url_suffix : String @doc(description: "Product URL Suffix")
+    category_url_suffix : String @doc(description: "Category URL Suffix")
+    product_use_categories : Int @doc(description: "Use Categories Path for Product URLs")
+    save_rewrites_history : Int @doc(description: "Create Permanent Redirect for URLs if URL Key Changed")
+    title_separator : String @doc(description: "Page Title Separator")
+    category_canonical_tag : Int @doc(description: "Use Canonical Link Meta Tag For Categories")
+    product_canonical_tag : Int @doc(description: "Use Canonical Link Meta Tag For Products")
+    list_mode : String @doc(description: "List Mode")
+    grid_per_page_values : String @doc(description: "Products per Page on Grid Allowed Values")
+    list_per_page_values : String @doc(description: "Products per Page on List Allowed Values")
+    grid_per_page : Int @doc(description: "Products per Page on Grid Default Value")
+    list_per_page : Int @doc(description: "Products per Page on List Default Value")
+    flat_catalog_category : Int @doc(description: "Use Flat Catalog Category")
+    catalog_default_sort_by : String @doc(description: "Default Sort By")
+    parse_url_directives : Int @doc(description: "Parse URL directives")
+    remember_pagination : Int @doc(description: "Remember Pagination")
+}

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/StoreConfigTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/StoreConfigTest.php
@@ -30,20 +30,13 @@ class StoreConfigTest extends GraphQlAbstract
   storeConfig{
     product_url_suffix,
     category_url_suffix,
-    product_use_categories,
-    save_rewrites_history,
     title_separator,
-    category_canonical_tag,
-    product_canonical_tag,
     list_mode,
     grid_per_page_values,
     list_per_page_values,
     grid_per_page,
     list_per_page,
-    flat_catalog_category,
-    catalog_default_sort_by,
-    parse_url_directives,
-    remember_pagination
+    catalog_default_sort_by
   }
 }
 QUERY;

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/StoreConfigTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/StoreConfigTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Store;
+
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+/**
+ * Test the GraphQL endpoint's StoreConfigs query for Catalog Configs
+ */
+class StoreConfigTest extends GraphQlAbstract
+{
+    protected function setUp()
+    {
+        $this->markTestIncomplete('https://github.com/magento/graphql-ce/issues/167');
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Store/_files/store.php
+     */
+    public function testGetStoreConfig()
+    {
+        $query
+            = <<<QUERY
+{
+  storeConfig{
+    product_url_suffix,
+    category_url_suffix,
+    product_use_categories,
+    save_rewrites_history,
+    title_separator,
+    category_canonical_tag,
+    product_canonical_tag,
+    list_mode,
+    grid_per_page_values,
+    list_per_page_values,
+    grid_per_page,
+    list_per_page,
+    flat_catalog_category,
+    catalog_default_sort_by,
+    parse_url_directives,
+    remember_pagination
+  }
+}
+QUERY;
+        $response = $this->graphQlQuery($query);
+        $this->assertArrayHasKey('storeConfig', $response);
+
+        //TODO: provide assertions after unmarking test as incomplete
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/StoreConfigTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/StoreConfigTest.php
@@ -5,7 +5,7 @@
  */
 declare(strict_types=1);
 
-namespace Magento\GraphQl\Store;
+namespace Magento\GraphQl\Catalog;
 
 use Magento\TestFramework\TestCase\GraphQlAbstract;
 


### PR DESCRIPTION
### Description (*)
Provided catalog configs for PWA in scope of StoreConfig type.

```
{
  storeConfig{
    product_url_suffix,
    category_url_suffix,
    title_separator,
    list_mode,
    grid_per_page_values,
    list_per_page_values,
    grid_per_page,
    list_per_page,
    catalog_default_sort_by
  }
}
```

![image](https://user-images.githubusercontent.com/20116393/57010806-59e10200-6c07-11e9-9881-18184dc18511.png)


### Fixed Issues (if relevant)
1. #535: Expose catalog configuration data as a new info query type.