### PR TITLE
Prevent Error When Getting Payment Method Before Setting

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/SelectedPaymentMethod.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/SelectedPaymentMethod.php
@@ -34,9 +34,15 @@ class SelectedPaymentMethod implements ResolverInterface
             return [];
         }
 
+        try {
+            $methodTitle = $payment->getMethodInstance()->getTitle();
+        } catch (LocalizedException $e) {
+            $methodTitle = '';
+        }
+
         return [
-            'code' => $payment->getMethod(),
-            'title' => $payment->getMethodInstance()->getTitle(),
+            'code' => $payment->getMethod() ?? '',
+            'title' => $methodTitle,
             'purchase_order_number' => $payment->getPoNumber(),
         ];
     }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetSelectedPaymentMethodTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetSelectedPaymentMethodTest.php
@@ -51,6 +51,27 @@ class GetSelectedPaymentMethodTest extends GraphQlAbstract
 
     /**
      * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/enable_offline_payment_methods.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_shipping_address.php
+     */
+    public function testGetSelectedPaymentMethodBeforeSet()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query, [], '', $this->getHeaderMap());
+
+        $this->assertArrayHasKey('cart', $response);
+        $this->assertArrayHasKey('selected_payment_method', $response['cart']);
+        $this->assertArrayHasKey('code', $response['cart']['selected_payment_method']);
+        $this->assertEquals('', $response['cart']['selected_payment_method']['code']);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
      * @expectedException \Exception
      */
     public function testGetSelectedPaymentMethodFromNonExistentCart()

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/GetSelectedPaymentMethodTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/GetSelectedPaymentMethodTest.php
@@ -50,6 +50,26 @@ class GetSelectedPaymentMethodTest extends GraphQlAbstract
     }
 
     /**
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/enable_offline_payment_methods.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_shipping_address.php
+     */
+    public function testGetSelectedPaymentMethodBeforeSet()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query);
+
+        $this->assertArrayHasKey('cart', $response);
+        $this->assertArrayHasKey('selected_payment_method', $response['cart']);
+        $this->assertArrayHasKey('code', $response['cart']['selected_payment_method']);
+        $this->assertEquals('', $response['cart']['selected_payment_method']['code']);
+    }
+
+    /**
      * @expectedException \Exception
      */
     public function testGetSelectedPaymentMethodFromNonExistentCart()


### PR DESCRIPTION
### Description (*)
Calling [`Magento\Quote\Model\Quote\Payment::getMethodInstance`](https://github.com/magento/graphql-ce/blob/b2ce2a37d921b5ad88fc38663fc0ff3dd6c582d1/app/code/Magento/Payment/Model/Info.php#L105)
throws an exception when the method is not set. This would trigger and error
when requsting the `selected_payment_method` cart property. This commit returns
an empty string instead.

### Fixed Issues (if relevant)
1. magento/graphql-ce#667

### Manual testing scenarios (*)
1. Create empty cart
```graphql
mutation {
   createEmptyCart
}
```
2. Query cart for selected payment method
```graphql
query getCart($cart_id:String!) {
  cart(cart_id:$cart_id) {
    selected_payment_method {
      code
      title
    }
  }
}
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
