### PR TITLE
cms block, get by identifier and #635

### DIFF
--- a/app/code/Magento/CmsGraphQl/Model/Resolver/Blocks.php
+++ b/app/code/Magento/CmsGraphQl/Model/Resolver/Blocks.php
@@ -46,8 +46,8 @@ class Blocks implements ResolverInterface
     ) {
 
         $blockIdentifiers = $this->getBlockIdentifiers($args);
-        $blocksData = $this->getBlocksData($blockIdentifiers);
-
+        $scopeIdentifiers  = $this->getScopeIdentifiers($args);
+        $blocksData = $this->getBlocksData($blockIdentifiers,$scopeIdentifiers[0]);
         $resultData = [
             'items' => $blocksData,
         ];
@@ -69,20 +69,36 @@ class Blocks implements ResolverInterface
 
         return $args['identifiers'];
     }
-
+    
+    /**
+     * Get scope identifiers
+     *
+     * @param array $args
+     * @return string[]
+     * @throws GraphQlInputException
+     */
+	private function getScopeIdentifiers(array $args): array
+    {
+        if (!isset($args['scope_code']) || !is_array($args['scope_code']) || count($args['scope_code']) === 0) {
+            throw new GraphQlInputException(__('Scope Code of CMS blocks should be specified'));
+        }
+        return $args['scope_code'];
+    }
+    
     /**
      * Get blocks data
      *
      * @param array $blockIdentifiers
+     * @param string $scopeargs
      * @return array
      * @throws GraphQlNoSuchEntityException
      */
-    private function getBlocksData(array $blockIdentifiers): array
+    private function getBlocksData(array $blockIdentifiers,$scopeargs): array
     {
         $blocksData = [];
         foreach ($blockIdentifiers as $blockIdentifier) {
             try {
-                $blocksData[$blockIdentifier] = $this->blockDataProvider->getData($blockIdentifier);
+                $blocksData[$blockIdentifier] = $this->blockDataProvider->getData($blockIdentifier,$scopeargs);
             } catch (NoSuchEntityException $e) {
                 $blocksData[$blockIdentifier] = new GraphQlNoSuchEntityException(__($e->getMessage()), $e);
             }

--- a/app/code/Magento/CmsGraphQl/Model/Resolver/DataProvider/Block.php
+++ b/app/code/Magento/CmsGraphQl/Model/Resolver/DataProvider/Block.php
@@ -71,7 +71,7 @@ class Block
         	$store = $this->store->load($scopeargs,'code');
         	if(!$store->getId()){
         		throw new NoSuchEntityException(
-        				__('Store Does Not Exist')
+        				__('Store View Does Not Exist')
         		);
         	}
         	$block = $this->blockIdentifier->execute($blockIdentifier,(int)$store->getId());

--- a/app/code/Magento/CmsGraphQl/Model/Resolver/DataProvider/Block.php
+++ b/app/code/Magento/CmsGraphQl/Model/Resolver/DataProvider/Block.php
@@ -6,37 +6,54 @@
 declare(strict_types=1);
 
 namespace Magento\CmsGraphQl\Model\Resolver\DataProvider;
-
 use Magento\Cms\Api\BlockRepositoryInterface;
 use Magento\Cms\Api\Data\BlockInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Widget\Model\Template\FilterEmulate;
-
+use Magento\Cms\Model\GetBlockByIdentifier;
 /**
  * Cms block data provider
  */
 class Block
 {
+	/**
+	 * @var BlockRepositoryInterface
+	 */
+	private $blockRepository;
+	
     /**
-     * @var BlockRepositoryInterface
+     * @var GetBlockByIdentifier
      */
-    private $blockRepository;
+    private $blockIdentifier;
 
     /**
      * @var FilterEmulate
      */
     private $widgetFilter;
+    
+    /**
+     * @var \Magento\Store\Model\Store
+     */
+    private $store;
 
     /**
      * @param BlockRepositoryInterface $blockRepository
      * @param FilterEmulate $widgetFilter
+     * @param GetBlockByIdentifier $widgetFilter
+     * @param \Magento\Store\Model\Store $store
+     * 
      */
+    
     public function __construct(
-        BlockRepositoryInterface $blockRepository,
-        FilterEmulate $widgetFilter
+    	BlockRepositoryInterface $blockRepository,
+        FilterEmulate $widgetFilter,
+    	GetBlockByIdentifier $blockIdentifier,
+    	\Magento\Store\Model\Store $store
     ) {
-        $this->blockRepository = $blockRepository;
+    	$this->blockRepository = $blockRepository;
         $this->widgetFilter = $widgetFilter;
+        $this->blockIdentifier = $blockIdentifier;
+        $this->store = $store;
     }
 
     /**
@@ -46,20 +63,28 @@ class Block
      * @return array
      * @throws NoSuchEntityException
      */
-    public function getData(string $blockIdentifier): array
+    public function getData(string $blockIdentifier,string $scopeargs): array
     {
-        $block = $this->blockRepository->getById($blockIdentifier);
-
-        if (false === $block->isActive()) {
-            throw new NoSuchEntityException(
-                __('The CMS block with the "%1" ID doesn\'t exist.', $blockIdentifier)
-            );
+        if($scopeargs==null){
+        	$block = $this->blockRepository->getById($blockIdentifier);
+        }else{
+        	$store = $this->store->load($scopeargs,'code');
+        	if(!$store->getId()){
+        		throw new NoSuchEntityException(
+        				__('Store Does Not Exist')
+        		);
+        	}
+        	$block = $this->blockIdentifier->execute($blockIdentifier,(int)$store->getId());
         }
-
+        	
+        if (false === $block->isActive()) {
+        	throw new NoSuchEntityException(
+        			__('The CMS block with the "%1" ID doesn\'t exist.', $blockIdentifier)
+        	);
+        }
         $renderedContent = $this->widgetFilter->filter($block->getContent());
 
         $blockData = [
-            BlockInterface::BLOCK_ID => $block->getId(),
             BlockInterface::IDENTIFIER => $block->getIdentifier(),
             BlockInterface::TITLE => $block->getTitle(),
             BlockInterface::CONTENT => $renderedContent,

--- a/app/code/Magento/CmsGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CmsGraphQl/etc/schema.graphqls
@@ -15,7 +15,8 @@ type Query {
         id: Int @doc(description: "Id of the CMS page")
     ): CmsPage @resolver(class: "Magento\\CmsGraphQl\\Model\\Resolver\\Page") @doc(description: "The CMS page query returns information about a CMS page") @cache(cacheTag: "cms_p", cacheIdentity: "Magento\\CmsGraphQl\\Model\\Resolver\\Page\\Identity")
     cmsBlocks (
-        identifiers: [String] @doc(description: "Identifiers of the CMS blocks")
+        identifiers: [String] @doc(description: "Identifiers of the CMS blocks"),
+        scope_code: [String] @doc(description: "Scope Code of the CMS blocks")
     ): CmsBlocks @resolver(class: "Magento\\CmsGraphQl\\Model\\Resolver\\Blocks") @doc(description: "The CMS block query returns information about CMS blocks") @cache(cacheTag: "cms_b", cacheIdentity: "Magento\\CmsGraphQl\\Model\\Resolver\\Block\\Identity")
 }
 


### PR DESCRIPTION
fixed issue #635 cms block, get by identifier


### Description (*)
fixed issue #635 cms block, get by identifier

### Fixed Issues (if relevant)
1. magento/graphql-ce#635: cms block, get by identifier

### Manual testing scenarios (*)

Steps to reproduce (*)

    Create atleast 2 store views
    Create 2 cms blocks, with the same identifier, set storeview scope two the 2 different store views created at the top
    3: Get the cms block with the identifier - it will ALWAYS get the cms block from the default webstore.
    4: (You can check with storeConfig: { code } that you actually are running with a different scope.

Now the query will be
```graphql
{
  storeConfig {
    code
  }
  cmsBlocks(identifiers: "test_page",
  scope_code: ""
  ) {
    items {
      content
    }
  }
}
```

in scope_code store code need to be passed and it will fetch according to store 
### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
