### PR TITLE
GraphQL-672: Change customer password

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/ChangeCustomerPasswordTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/ChangeCustomerPasswordTest.php
@@ -10,6 +10,7 @@ namespace Magento\GraphQl\Customer;
 use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Model\CustomerAuthUpdate;
 use Magento\Customer\Model\CustomerRegistry;
+use Magento\Framework\Exception\AuthenticationException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Integration\Api\CustomerTokenServiceInterface;
@@ -202,6 +203,12 @@ class ChangeCustomerPasswordTest extends GraphQlAbstract
         $this->customerAuthUpdate->saveAuth($customerId);
     }
 
+    /**
+     * @param $currentPassword
+     * @param $newPassword
+     *
+     * @return string
+     */
     private function getChangePassQuery($currentPassword, $newPassword)
     {
         $query = <<<QUERY
@@ -224,7 +231,9 @@ QUERY;
     /**
      * @param string $email
      * @param string $password
+     *
      * @return array
+     * @throws AuthenticationException
      */
     private function getCustomerAuthHeaders(string $email, string $password): array
     {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/ChangeCustomerPasswordTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/ChangeCustomerPasswordTest.php
@@ -121,11 +121,28 @@ class ChangeCustomerPasswordTest extends GraphQlAbstract
         $customerEmail = 'customer@example.com';
         $oldCustomerPassword = 'password';
         $newCustomerPassword = 'anotherPassword1';
-        $incorrectPassword = '';
+        $currentCustomerPassword = '';
 
-        $query = $this->getChangePassQuery($incorrectPassword, $newCustomerPassword);
+        $query = $this->getChangePassQuery($currentCustomerPassword, $newCustomerPassword);
 
         $headerMap = $this->getCustomerAuthHeaders($customerEmail, $oldCustomerPassword);
+        $this->graphQlMutation($query, [], '', $headerMap);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @expectedException \Exception
+     * @expectedExceptionMessage Specify the "newPassword" value.
+     */
+    public function testChangePasswordIfNewPasswordIsEmpty()
+    {
+        $customerEmail = 'customer@example.com';
+        $currentCustomerPassword = 'password';
+        $newCustomerPassword = '';
+
+        $query = $this->getChangePassQuery($currentCustomerPassword, $newCustomerPassword);
+
+        $headerMap = $this->getCustomerAuthHeaders($customerEmail, $currentCustomerPassword);
         $this->graphQlMutation($query, [], '', $headerMap);
     }
 

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/ChangeCustomerPasswordTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/ChangeCustomerPasswordTest.php
@@ -111,6 +111,24 @@ class ChangeCustomerPasswordTest extends GraphQlAbstract
         $this->graphQlMutation($query, [], '', $headerMap);
     }
 
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @expectedException \Exception
+     * @expectedExceptionMessage Specify the "currentPassword" value.
+     */
+    public function testChangePasswordIfCurrentPasswordIsEmpty()
+    {
+        $customerEmail = 'customer@example.com';
+        $oldCustomerPassword = 'password';
+        $newCustomerPassword = 'anotherPassword1';
+        $incorrectPassword = '';
+
+        $query = $this->getChangePassQuery($incorrectPassword, $newCustomerPassword);
+
+        $headerMap = $this->getCustomerAuthHeaders($customerEmail, $oldCustomerPassword);
+        $this->graphQlMutation($query, [], '', $headerMap);
+    }
+
     private function getChangePassQuery($currentPassword, $newPassword)
     {
         $query = <<<QUERY

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/ChangeCustomerPasswordTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/ChangeCustomerPasswordTest.php
@@ -70,7 +70,7 @@ class ChangeCustomerPasswordTest extends GraphQlAbstract
         $headerMap = $this->getCustomerAuthHeaders($customerEmail, $currentPassword);
 
         $response = $this->graphQlMutation($query, [], '', $headerMap);
-        $this->assertEquals($customerEmail, $response['changePassword']['email']);
+        $this->assertEquals($customerEmail, $response['changeCustomerPassword']['email']);
 
         try {
             // registry contains the old password hash so needs to be reset

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Customer/_files/enable_customer_account_confirmation.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Customer/_files/enable_customer_account_confirmation.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+// TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
+declare(strict_types=1);
+
+use Magento\Customer\Model\AccountConfirmation;
+use Magento\Framework\App\Config\Storage\Writer;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+
+$objectManager = Bootstrap::getObjectManager();
+/** @var Writer $configWriter */
+$configWriter = $objectManager->get(WriterInterface::class);
+
+$configWriter->save(AccountConfirmation::XML_PATH_IS_CONFIRM, 1);
+
+$scopeConfig = $objectManager->get(ScopeConfigInterface::class);
+$scopeConfig->clean();

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Customer/_files/enable_customer_account_confirmation_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Customer/_files/enable_customer_account_confirmation_rollback.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+// TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
+declare(strict_types=1);
+
+use Magento\Framework\App\Config\Storage\Writer;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+$objectManager = Bootstrap::getObjectManager();
+/** @var Writer  $configWriter */
+$configWriter = $objectManager->create(WriterInterface::class);
+
+$configWriter->delete('customer/create_account/confirm');


### PR DESCRIPTION
https://github.com/magento/graphql-ce/issues/672

Test cases:

```
\Magento\GraphQl\Customer\ChangeCustomerPasswordTest
- testChangePasswordIfCurrentPasswordIsEmpty
- testChangePasswordIfNewPasswordIsEmpty
- testChangePasswordIfCustomerIsLocked (see \Magento\GraphQl\Customer\UpdateCustomerTest::lockCustomer)
- tesChangeCustomerAddressIfAccountIsNotConfirmed
```