### PR TITLE
customizable_options.values contains everything but value(s)

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/Product.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/Product.php
@@ -74,7 +74,7 @@ class Product
     ): SearchResultsInterface {
         /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $collection */
         $collection = $this->collectionFactory->create();
-        $attributes = array_unique(array_merge($attributes, ['small_image', 'thumbnail', 'image']));
+
         $this->collectionProcessor->process($collection, $searchCriteria, $attributes);
 
         if (!$isChildSearch) {

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/Product.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/Product.php
@@ -74,7 +74,7 @@ class Product
     ): SearchResultsInterface {
         /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $collection */
         $collection = $this->collectionFactory->create();
-
+        $attributes = array_unique(array_merge($attributes, ['small_image', 'thumbnail', 'image']));
         $this->collectionProcessor->process($collection, $searchCriteria, $attributes);
 
         if (!$isChildSearch) {

--- a/app/code/Magento/QuoteGraphQl/Model/CartItem/DataProvider/CustomizableOptionValue/Multiple.php
+++ b/app/code/Magento/QuoteGraphQl/Model/CartItem/DataProvider/CustomizableOptionValue/Multiple.php
@@ -54,6 +54,7 @@ class Multiple implements CustomizableOptionValueInterface
             $selectedOptionValueData[] = [
                 'id' => $selectedOption->getId(),
                 'label' => $optionValue->getTitle(),
+                'value' => $optionId,
                 'price' => [
                     'type' => strtoupper($optionValue->getPriceType()),
                     'units' => $priceValueUnits,

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -314,7 +314,6 @@ type SelectedCustomizableOption {
 type SelectedCustomizableOptionValue {
     id: Int!
     label: String!
-    value: String
     price: CartItemSelectedOptionValuePrice!
 }
 

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -314,7 +314,7 @@ type SelectedCustomizableOption {
 type SelectedCustomizableOptionValue {
     id: Int!
     label: String!
-    value: String @deprecated (reason: "The value field is deprecated. It was moved to CartItemSelectedOptionValuePrice.")
+    value: String!
     price: CartItemSelectedOptionValuePrice!
 }
 

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -314,6 +314,7 @@ type SelectedCustomizableOption {
 type SelectedCustomizableOptionValue {
     id: Int!
     label: String!
+    value: String @deprecated (reason: "The value field is deprecated. It was moved to CartItemSelectedOptionValuePrice.")
     price: CartItemSelectedOptionValuePrice!
 }
 

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/AddSimpleProductWithCustomOptionsToCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/AddSimpleProductWithCustomOptionsToCartTest.php
@@ -64,9 +64,10 @@ class AddSimpleProductWithCustomOptionsToCartTest extends GraphQlAbstract
         $customizableOptionsOutput = $response['addSimpleProductsToCart']['cart']['items'][0]['customizable_options'];
         $assignedOptionsCount = count($customOptionsValues);
         for ($counter = 0; $counter < $assignedOptionsCount; $counter++) {
+            $expectedValues = $this->buildExpectedValuesArray($customOptionsValues[$counter]['value_string']);
             self::assertEquals(
-                $customOptionsValues[$counter]['value_string'],
-                $customizableOptionsOutput[$counter]['values'][0]['value']
+                $expectedValues,
+                $customizableOptionsOutput[$counter]['values']
             );
         }
     }
@@ -150,18 +151,38 @@ QUERY;
             $optionType = $customOption->getType();
             if ($optionType == 'field' || $optionType == 'area') {
                 $customOptionsValues[] = [
-                    'id' => (int) $customOption->getOptionId(),
+                    'id' => (int)$customOption->getOptionId(),
                     'value_string' => 'test'
                 ];
             } elseif ($optionType == 'drop_down') {
                 $optionSelectValues = $customOption->getValues();
                 $customOptionsValues[] = [
-                    'id' => (int) $customOption->getOptionId(),
+                    'id' => (int)$customOption->getOptionId(),
                     'value_string' => reset($optionSelectValues)->getOptionTypeId()
+                ];
+            } elseif ($optionType == 'multiple') {
+                $customOptionsValues[] = [
+                    'id' => (int)$customOption->getOptionId(),
+                    'value_string' => '[' . implode(',', array_keys($customOption->getValues())) . ']'
                 ];
             }
         }
-
         return $customOptionsValues;
+    }
+
+    /**
+     * Build the part of expected response.
+     *
+     * @param string $assignedValue
+     * @return array
+     */
+    private function buildExpectedValuesArray(string $assignedValue) : array
+    {
+        $assignedOptionsArray = explode(',', trim($assignedValue, '[]'));
+        $expectedArray = [];
+        foreach ($assignedOptionsArray as $assignedOption) {
+            $expectedArray[] = ['value' => $assignedOption];
+        }
+        return $expectedArray;
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/AddVirtualProductWithCustomOptionsToCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/AddVirtualProductWithCustomOptionsToCartTest.php
@@ -64,9 +64,10 @@ class AddVirtualProductWithCustomOptionsToCartTest extends GraphQlAbstract
         $customizableOptionsOutput = $response['addVirtualProductsToCart']['cart']['items'][0]['customizable_options'];
         $assignedOptionsCount = count($customOptionsValues);
         for ($counter = 0; $counter < $assignedOptionsCount; $counter++) {
+            $expectedValues = $this->buildExpectedValuesArray($customOptionsValues[$counter]['value_string']);
             self::assertEquals(
-                $customOptionsValues[$counter]['value_string'],
-                $customizableOptionsOutput[$counter]['values'][0]['value']
+                $expectedValues,
+                $customizableOptionsOutput[$counter]['values']
             );
         }
     }
@@ -150,18 +151,39 @@ QUERY;
             $optionType = $customOption->getType();
             if ($optionType == 'field' || $optionType == 'area') {
                 $customOptionsValues[] = [
-                    'id' => (int) $customOption->getOptionId(),
+                    'id' => (int)$customOption->getOptionId(),
                     'value_string' => 'test'
                 ];
             } elseif ($optionType == 'drop_down') {
                 $optionSelectValues = $customOption->getValues();
                 $customOptionsValues[] = [
-                    'id' => (int) $customOption->getOptionId(),
+                    'id' => (int)$customOption->getOptionId(),
                     'value_string' => reset($optionSelectValues)->getOptionTypeId()
+                ];
+            } elseif ($optionType == 'multiple') {
+                $customOptionsValues[] = [
+                    'id' => (int)$customOption->getOptionId(),
+                    'value_string' => '[' . implode(',', array_keys($customOption->getValues())) . ']'
                 ];
             }
         }
 
         return $customOptionsValues;
+    }
+
+    /**
+     * Build the part of expected response.
+     *
+     * @param string $assignedValue
+     * @return array
+     */
+    private function buildExpectedValuesArray(string $assignedValue) : array
+    {
+        $assignedOptionsArray = explode(',', trim($assignedValue, '[]'));
+        $expectedArray = [];
+        foreach ($assignedOptionsArray as $assignedOption) {
+            $expectedArray[] = ['value' => $assignedOption];
+        }
+        return $expectedArray;
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_with_options.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_with_options.php
@@ -84,6 +84,28 @@ $options = [
                 'sort_order' => 2,
             ],
         ],
+    ],
+    [
+        'title' => 'multiple option',
+        'type' => 'multiple',
+        'is_require' => false,
+        'sort_order' => 5,
+        'values' => [
+            [
+                'title' => 'multiple option 1',
+                'price' => 10,
+                'price_type' => 'fixed',
+                'sku' => 'multiple option 1 sku',
+                'sort_order' => 1,
+            ],
+            [
+                'title' => 'multiple option 2',
+                'price' => 20,
+                'price_type' => 'fixed',
+                'sku' => 'multiple option 2 sku',
+                'sort_order' => 2,
+            ],
+        ],
     ]
 ];
 

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_virtual_with_options.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_virtual_with_options.php
@@ -84,6 +84,28 @@ $options = [
                 'sort_order' => 2,
             ],
         ],
+    ],
+    [
+        'title' => 'multiple option',
+        'type' => 'multiple',
+        'is_require' => false,
+        'sort_order' => 5,
+        'values' => [
+            [
+                'title' => 'multiple option 1',
+                'price' => 10,
+                'price_type' => 'fixed',
+                'sku' => 'multiple option 1 sku',
+                'sort_order' => 1,
+            ],
+            [
+                'title' => 'multiple option 2',
+                'price' => 20,
+                'price_type' => 'fixed',
+                'sku' => 'multiple option 2 sku',
+                'sort_order' => 2,
+            ],
+        ],
     ]
 ];
 


### PR DESCRIPTION
### Description (*)
Original Issue: https://github.com/magento/graphql-ce/issues/698

according to the issue https://github.com/magento/graphql-ce/issues/474 and PR https://github.com/magento/graphql-ce/pull/525
The field 'value' was moved to 'CartItemSelectedOptionValuePrice'
I debugged and rechecked all product custom options and field 'value' is missed and always return NULL.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
