### PR TITLE
[Checkout coverage] Added discount information to shopping cart

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/CartPrices.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/CartPrices.php
@@ -56,6 +56,7 @@ class CartPrices implements ResolverInterface
                 'value' => $cartTotals->getSubtotalWithDiscount(), 'currency' => $currency
             ],
             'applied_taxes' => $this->getAppliedTaxes($cartTotals, $currency),
+            'discount' => $this->getDiscount($cartTotals, $currency),
             'model' => $quote
         ];
     }
@@ -83,5 +84,20 @@ class CartPrices implements ResolverInterface
             ];
         }
         return $appliedTaxesData;
+    }
+
+    /**
+     * Returns information about an applied discount
+     *
+     * @param Total $total
+     * @param string $currency
+     * @return array
+     */
+    private function getDiscount(Total $total, string $currency)
+    {
+        return [
+            'label' => $total->getDiscountDescription(),
+            'amount' => ['value' => $total->getDiscountAmount(), "currency" => $currency]
+        ];
     }
 }

--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/CartPrices.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/CartPrices.php
@@ -96,8 +96,8 @@ class CartPrices implements ResolverInterface
     private function getDiscount(Total $total, string $currency)
     {
         return [
-            'label' => $total->getDiscountDescription(),
-            'amount' => ['value' => $total->getDiscountAmount(), "currency" => $currency]
+            'label' => explode(', ', $total->getDiscountDescription()),
+            'amount' => ['value' => $total->getDiscountAmount(), 'currency' => $currency]
         ];
     }
 }

--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/CartPrices.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/CartPrices.php
@@ -91,10 +91,13 @@ class CartPrices implements ResolverInterface
      *
      * @param Total $total
      * @param string $currency
-     * @return array
+     * @return array|null
      */
     private function getDiscount(Total $total, string $currency)
     {
+        if ($total->getDiscountAmount() === 0) {
+            return null;
+        }
         return [
             'label' => explode(', ', $total->getDiscountDescription()),
             'amount' => ['value' => $total->getDiscountAmount(), 'currency' => $currency]

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -142,11 +142,17 @@ type CartPrices {
     grand_total: Money
     subtotal_including_tax: Money
     subtotal_excluding_tax: Money
+    discount: CartDiscountItem
     subtotal_with_discount_excluding_tax: Money
     applied_taxes: [CartTaxItem]
 }
 
 type CartTaxItem {
+    amount: Money!
+    label: String!
+}
+
+type CartDiscountItem {
     amount: Money!
     label: String!
 }

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -142,7 +142,7 @@ type CartPrices {
     grand_total: Money
     subtotal_including_tax: Money
     subtotal_excluding_tax: Money
-    discount: CartDiscountItem
+    discount: CartDiscount
     subtotal_with_discount_excluding_tax: Money
     applied_taxes: [CartTaxItem]
 }
@@ -152,9 +152,9 @@ type CartTaxItem {
     label: String!
 }
 
-type CartDiscountItem {
+type CartDiscount {
     amount: Money!
-    label: String!
+    label: [String!]!
 }
 
 type SetPaymentMethodOnCartOutput {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CartDiscountTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CartDiscountTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Quote\Customer;
+
+use Magento\GraphQl\Quote\GetMaskedQuoteIdByReservedOrderId;
+use Magento\Integration\Api\CustomerTokenServiceInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+/**
+ * Test is getting cart discount for registered customer.
+ */
+class CartDiscountTest extends GraphQlAbstract
+{
+    /**
+     * @var CustomerTokenServiceInterface
+     */
+    private $customerTokenService;
+
+    /**
+     * @var GetMaskedQuoteIdByReservedOrderId
+     */
+    private $getMaskedQuoteIdByReservedOrderId;
+
+    protected function setUp()
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->getMaskedQuoteIdByReservedOrderId = $objectManager->get(GetMaskedQuoteIdByReservedOrderId::class);
+        $this->customerTokenService = $objectManager->get(CustomerTokenServiceInterface::class);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     */
+    public function testGetDiscountInformation()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query, [], '', $this->getHeaderMap());
+        $discountResponse = $response['cart']['prices']['discount'];
+        self::assertEquals(-10, $discountResponse['amount']['value']);
+        self::assertEquals(['50% Off for all orders'], $discountResponse['label']);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/Checkout/_files/discount_10percent_generalusers.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/apply_coupon.php
+     */
+    public function testGetDiscountInformationWithTwoRulesApplied()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query, [], '', $this->getHeaderMap());
+        $discountResponse = $response['cart']['prices']['discount'];
+        self::assertEquals(-11, $discountResponse['amount']['value']);
+        self::assertEquals(['50% Off for all orders', 'Test Coupon for General'], $discountResponse['label']);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     */
+    public function testGetDiscountInformationWithNoRulesApplied()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query, [], '', $this->getHeaderMap());
+        self::assertEquals(null, $response['cart']['prices']['discount']);
+    }
+
+    /**
+     * Generates GraphQl query for retrieving cart discount
+     *
+     * @param string $maskedQuoteId
+     * @return string
+     */
+    private function getQuery(string $maskedQuoteId): string
+    {
+        return <<<QUERY
+{
+  cart(cart_id: "$maskedQuoteId") {
+    prices {
+      discount {
+        label
+        amount {
+          value
+          currency
+        }
+      }
+    }
+  }
+}
+QUERY;
+    }
+
+    /**
+     * @param string $username
+     * @param string $password
+     * @return array
+     */
+    private function getHeaderMap(string $username = 'customer@example.com', string $password = 'password'): array
+    {
+        $customerToken = $this->customerTokenService->createCustomerAccessToken($username, $password);
+        $headerMap = ['Authorization' => 'Bearer ' . $customerToken];
+        return $headerMap;
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CartTotalsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CartTotalsTest.php
@@ -154,44 +154,6 @@ class CartTotalsTest extends GraphQlAbstract
     }
 
     /**
-     * @magentoApiDataFixture Magento/Customer/_files/customer.php
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
-     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
-     */
-    public function testGetDiscountInformation()
-    {
-        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
-        $query = $this->getQuery($maskedQuoteId);
-        $response = $this->graphQlQuery($query, [], '', $this->getHeaderMap());
-
-        $discountResponse = $response['cart']['prices']['discount'];
-        self::assertEquals(-10, $discountResponse['amount']['value']);
-        self::assertEquals(['50% Off for all orders'], $discountResponse['label']);
-    }
-
-    /**
-     * @magentoApiDataFixture Magento/Customer/_files/customer.php
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
-     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
-     * @magentoApiDataFixture Magento/Checkout/_files/discount_10percent_generalusers.php
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/apply_coupon.php
-     */
-    public function testGetDiscountInformationWithTwoRulesApplied()
-    {
-        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
-        $query = $this->getQuery($maskedQuoteId);
-        $response = $this->graphQlQuery($query, [], '', $this->getHeaderMap());
-
-        $discountResponse = $response['cart']['prices']['discount'];
-        self::assertEquals(-11, $discountResponse['amount']['value']);
-        self::assertEquals(['50% Off for all orders', 'Test Coupon for General'], $discountResponse['label']);
-    }
-
-    /**
      * Generates GraphQl query for retrieving cart totals
      *
      * @param string $maskedQuoteId
@@ -220,13 +182,6 @@ class CartTotalsTest extends GraphQlAbstract
         currency
       }
       applied_taxes {
-        label
-        amount {
-          value
-          currency
-        }
-      }
-      discount {
         label
         amount {
           value

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CartTotalsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CartTotalsTest.php
@@ -154,6 +154,44 @@ class CartTotalsTest extends GraphQlAbstract
     }
 
     /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     */
+    public function testGetDiscountInformation()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query, [], '', $this->getHeaderMap());
+
+        $discountResponse = $response['cart']['prices']['discount'];
+        self::assertEquals(-10, $discountResponse['amount']['value']);
+        self::assertEquals('50% Off for all orders', $discountResponse['label']);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/Checkout/_files/discount_10percent_generalusers.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/apply_coupon.php
+     */
+    public function testGetDiscountInformationWithTwoRulesApplied()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query, [], '', $this->getHeaderMap());
+
+        $discountResponse = $response['cart']['prices']['discount'];
+        self::assertEquals(-11, $discountResponse['amount']['value']);
+        self::assertEquals('50% Off for all orders, Test Coupon for General', $discountResponse['label']);
+    }
+
+    /**
      * Generates GraphQl query for retrieving cart totals
      *
      * @param string $maskedQuoteId
@@ -182,6 +220,13 @@ class CartTotalsTest extends GraphQlAbstract
         currency
       }
       applied_taxes {
+        label
+        amount {
+          value
+          currency
+        }
+      }
+      discount {
         label
         amount {
           value

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CartTotalsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CartTotalsTest.php
@@ -168,7 +168,7 @@ class CartTotalsTest extends GraphQlAbstract
 
         $discountResponse = $response['cart']['prices']['discount'];
         self::assertEquals(-10, $discountResponse['amount']['value']);
-        self::assertEquals('50% Off for all orders', $discountResponse['label']);
+        self::assertEquals(['50% Off for all orders'], $discountResponse['label']);
     }
 
     /**
@@ -188,7 +188,7 @@ class CartTotalsTest extends GraphQlAbstract
 
         $discountResponse = $response['cart']['prices']['discount'];
         self::assertEquals(-11, $discountResponse['amount']['value']);
-        self::assertEquals('50% Off for all orders, Test Coupon for General', $discountResponse['label']);
+        self::assertEquals(['50% Off for all orders', 'Test Coupon for General'], $discountResponse['label']);
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartDiscountTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartDiscountTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Quote\Guest;
+
+use Magento\GraphQl\Quote\GetMaskedQuoteIdByReservedOrderId;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+/**
+ * Test is getting cart discount for guest customer.
+ */
+class CartDiscountTest extends GraphQlAbstract
+{
+    /**
+     * @var GetMaskedQuoteIdByReservedOrderId
+     */
+    private $getMaskedQuoteIdByReservedOrderId;
+
+    protected function setUp()
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->getMaskedQuoteIdByReservedOrderId = $objectManager->get(GetMaskedQuoteIdByReservedOrderId::class);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     */
+    public function testGetDiscountInformation()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query);
+        $discountResponse = $response['cart']['prices']['discount'];
+        self::assertEquals(-10, $discountResponse['amount']['value']);
+        self::assertEquals(['50% Off for all orders'], $discountResponse['label']);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/SalesRule/_files/coupon_code_with_wildcard.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/apply_coupon.php
+     */
+    public function testGetDiscountInformationWithTwoRulesApplied()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query);
+        $discountResponse = $response['cart']['prices']['discount'];
+        self::assertEquals(-15, $discountResponse['amount']['value']);
+        self::assertEquals(['50% Off for all orders', '5$ fixed discount on whole cart'], $discountResponse['label']);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     */
+    public function testGetDiscountInformationWithNoRulesApplied()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query);
+        self::assertEquals(null, $response['cart']['prices']['discount']);
+    }
+
+    /**
+     * Generates GraphQl query for retrieving cart discount.
+     *
+     * @param string $maskedQuoteId
+     * @return string
+     */
+    private function getQuery(string $maskedQuoteId): string
+    {
+        return <<<QUERY
+{
+  cart(cart_id: "$maskedQuoteId") {
+    prices {
+      discount {
+        label
+        amount {
+          value
+          currency
+        }
+      }
+    }
+  }
+}
+QUERY;
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
@@ -87,7 +87,6 @@ class CartTotalsTest extends GraphQlAbstract
      * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
-     * @group recent
      */
     public function testGetCartTotalsWithNoAddressSet()
     {
@@ -126,6 +125,34 @@ class CartTotalsTest extends GraphQlAbstract
     }
 
     /**
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     * @group recent
+     */
+    public function testGetDiscountInformation()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query);
+
+        $discountResponse = $response['cart']['prices']['discount'];
+        self::assertEquals(-20, $discountResponse['amount']['value']);
+        self::assertEquals('100% Off for all orders', $discountResponse['label']);
+    }
+
+    public function testGetDiscountInformationWithTwoRulesApplied()
+    {
+        self::fail();
+    }
+
+    public function testGetDiscountInformationForRuleWithNoLabel()
+    {
+        self::fail();
+    }
+
+    /**
      * Generates GraphQl query for retrieving cart totals
      *
      * @param string $maskedQuoteId
@@ -154,6 +181,13 @@ class CartTotalsTest extends GraphQlAbstract
         currency
       }
       applied_taxes {
+        label
+        amount {
+          value
+          currency
+        }
+      }
+      discount {
         label
         amount {
           value

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
@@ -138,7 +138,7 @@ class CartTotalsTest extends GraphQlAbstract
 
         $discountResponse = $response['cart']['prices']['discount'];
         self::assertEquals(-10, $discountResponse['amount']['value']);
-        self::assertEquals('50% Off for all orders', $discountResponse['label']);
+        self::assertEquals(['50% Off for all orders'], $discountResponse['label']);
     }
 
     /**
@@ -157,7 +157,7 @@ class CartTotalsTest extends GraphQlAbstract
 
         $discountResponse = $response['cart']['prices']['discount'];
         self::assertEquals(-15, $discountResponse['amount']['value']);
-        self::assertEquals('50% Off for all orders, 5$ fixed discount on whole cart', $discountResponse['label']);
+        self::assertEquals(['50% Off for all orders', '5$ fixed discount on whole cart'], $discountResponse['label']);
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
@@ -129,7 +129,6 @@ class CartTotalsTest extends GraphQlAbstract
      * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
-     * @group recent
      */
     public function testGetDiscountInformation()
     {
@@ -138,18 +137,27 @@ class CartTotalsTest extends GraphQlAbstract
         $response = $this->graphQlQuery($query);
 
         $discountResponse = $response['cart']['prices']['discount'];
-        self::assertEquals(-20, $discountResponse['amount']['value']);
-        self::assertEquals('100% Off for all orders', $discountResponse['label']);
+        self::assertEquals(-10, $discountResponse['amount']['value']);
+        self::assertEquals('50% Off for all orders', $discountResponse['label']);
     }
 
+    /**
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/SalesRule/_files/coupon_code_with_wildcard.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/apply_coupon.php
+     */
     public function testGetDiscountInformationWithTwoRulesApplied()
     {
-        self::fail();
-    }
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query);
 
-    public function testGetDiscountInformationForRuleWithNoLabel()
-    {
-        self::fail();
+        $discountResponse = $response['cart']['prices']['discount'];
+        self::assertEquals(-15, $discountResponse['amount']['value']);
+        self::assertEquals('50% Off for all orders, 5$ fixed discount on whole cart', $discountResponse['label']);
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
@@ -125,42 +125,6 @@ class CartTotalsTest extends GraphQlAbstract
     }
 
     /**
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
-     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
-     */
-    public function testGetDiscountInformation()
-    {
-        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
-        $query = $this->getQuery($maskedQuoteId);
-        $response = $this->graphQlQuery($query);
-
-        $discountResponse = $response['cart']['prices']['discount'];
-        self::assertEquals(-10, $discountResponse['amount']['value']);
-        self::assertEquals(['50% Off for all orders'], $discountResponse['label']);
-    }
-
-    /**
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
-     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
-     * @magentoApiDataFixture Magento/SalesRule/_files/coupon_code_with_wildcard.php
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/apply_coupon.php
-     */
-    public function testGetDiscountInformationWithTwoRulesApplied()
-    {
-        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
-        $query = $this->getQuery($maskedQuoteId);
-        $response = $this->graphQlQuery($query);
-
-        $discountResponse = $response['cart']['prices']['discount'];
-        self::assertEquals(-15, $discountResponse['amount']['value']);
-        self::assertEquals(['50% Off for all orders', '5$ fixed discount on whole cart'], $discountResponse['label']);
-    }
-
-    /**
      * Generates GraphQl query for retrieving cart totals
      *
      * @param string $maskedQuoteId
@@ -189,13 +153,6 @@ class CartTotalsTest extends GraphQlAbstract
         currency
       }
       applied_taxes {
-        label
-        amount {
-          value
-          currency
-        }
-      }
-      discount {
         label
         amount {
           value

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/discount_10percent_generalusers.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/discount_10percent_generalusers.php
@@ -14,6 +14,7 @@ $salesRule = $objectManager->create(\Magento\SalesRule\Model\Rule::class);
 $data = [
     'name' => 'Test Coupon for General',
     'is_active' => true,
+    'store_labels' => [0 => 'Test Coupon for General'],
     'website_ids' => [
         \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
             \Magento\Store\Model\StoreManagerInterface::class

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Customer\Model\GroupManagement as CustomerGroupManagement;
+use Magento\Framework\Api\DataObjectHelper;
+use Magento\SalesRule\Api\RuleRepositoryInterface;
+use Magento\SalesRule\Model\Data\Rule as RuleData;
+use Magento\Store\Model\StoreManagerInterface as StoreManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+
+$objectManager = Bootstrap::getObjectManager();
+/** @var RuleRepositoryInterface $ruleRepository */
+$ruleRepository = $objectManager->get(RuleRepositoryInterface::class);
+/** @var DataObjectHelper $dataObjectHelper */
+$dataObjectHelper = Bootstrap::getObjectManager()->get(DataObjectHelper::class);
+$ruleLabel = $objectManager->create(\Magento\SalesRule\Api\Data\RuleLabelInterface::class);
+$ruleLabelFactory = $objectManager->get(\Magento\SalesRule\Model\Data\RuleLabelFactory::class);
+
+
+/** @var RuleData $salesRule */
+$salesRule = $objectManager->create(RuleData::class);
+/** @var \Magento\SalesRule\Api\Data\RuleLabelInterface $ruleLabel */
+$ruleLabel = $ruleLabelFactory->create();
+$ruleLabel->setStoreId(0);
+$ruleLabel->setStoreLabel('50% Off for all orders');
+$ruleData = [
+        'name' => '50% Off for all orders',
+        'is_active' => 1,
+        'customer_group_ids' => [CustomerGroupManagement::NOT_LOGGED_IN_ID],
+        'coupon_type' => RuleData::COUPON_TYPE_NO_COUPON,
+        'conditions' => [],
+        'simple_action' => 'by_percent',
+        'discount_amount' => 50,
+        'discount_step' => 0,
+        'website_ids' => [
+            $objectManager->get(
+                StoreManagerInterface::class
+            )->getWebsite()->getId(),
+        ],
+        'discount_qty' => 0,
+        'apply_to_shipping' => 1,
+        'simple_free_shipping' => 1,
+];
+$dataObjectHelper->populateWithArray($salesRule, $ruleData, \Magento\SalesRule\Api\Data\RuleInterface::class);
+$salesRule->setStoreLabels([$ruleLabel]);
+
+$ruleRepository->save($salesRule);

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
@@ -34,7 +34,7 @@ $ruleLabel->setStoreLabel('50% Off for all orders');
 $ruleData = [
         'name' => '50% Off for all orders',
         'is_active' => 1,
-        'customer_group_ids' => [CustomerGroupManagement::NOT_LOGGED_IN_ID],
+        'customer_group_ids' => [CustomerGroupManagement::NOT_LOGGED_IN_ID, 1],
         'coupon_type' => RuleData::COUPON_TYPE_NO_COUPON,
         'conditions' => [],
         'simple_action' => 'by_percent',

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
@@ -15,7 +15,6 @@ use Magento\SalesRule\Model\Data\RuleLabelFactory;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 
-
 $objectManager = Bootstrap::getObjectManager();
 /** @var RuleRepositoryInterface $ruleRepository */
 $ruleRepository = $objectManager->get(RuleRepositoryInterface::class);

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon.php
@@ -7,9 +7,12 @@ declare(strict_types=1);
 
 use Magento\Customer\Model\GroupManagement as CustomerGroupManagement;
 use Magento\Framework\Api\DataObjectHelper;
+use Magento\SalesRule\Api\Data\RuleInterface;
+use Magento\SalesRule\Api\Data\RuleLabelInterface;
 use Magento\SalesRule\Api\RuleRepositoryInterface;
 use Magento\SalesRule\Model\Data\Rule as RuleData;
-use Magento\Store\Model\StoreManagerInterface as StoreManagerInterface;
+use Magento\SalesRule\Model\Data\RuleLabelFactory;
+use Magento\Store\Model\StoreManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 
 
@@ -18,13 +21,13 @@ $objectManager = Bootstrap::getObjectManager();
 $ruleRepository = $objectManager->get(RuleRepositoryInterface::class);
 /** @var DataObjectHelper $dataObjectHelper */
 $dataObjectHelper = Bootstrap::getObjectManager()->get(DataObjectHelper::class);
-$ruleLabel = $objectManager->create(\Magento\SalesRule\Api\Data\RuleLabelInterface::class);
-$ruleLabelFactory = $objectManager->get(\Magento\SalesRule\Model\Data\RuleLabelFactory::class);
+$ruleLabel = $objectManager->create(RuleLabelInterface::class);
+$ruleLabelFactory = $objectManager->get(RuleLabelFactory::class);
 
 
 /** @var RuleData $salesRule */
 $salesRule = $objectManager->create(RuleData::class);
-/** @var \Magento\SalesRule\Api\Data\RuleLabelInterface $ruleLabel */
+/** @var RuleLabelInterface $ruleLabel */
 $ruleLabel = $ruleLabelFactory->create();
 $ruleLabel->setStoreId(0);
 $ruleLabel->setStoreLabel('50% Off for all orders');
@@ -45,8 +48,9 @@ $ruleData = [
         'discount_qty' => 0,
         'apply_to_shipping' => 1,
         'simple_free_shipping' => 1,
+        'stop_rules_processing' => 0
 ];
-$dataObjectHelper->populateWithArray($salesRule, $ruleData, \Magento\SalesRule\Api\Data\RuleInterface::class);
+$dataObjectHelper->populateWithArray($salesRule, $ruleData, RuleInterface::class);
 $salesRule->setStoreLabels([$ruleLabel]);
 
 $ruleRepository->save($salesRule);

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon_rollback.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\SalesRule\Api\RuleRepositoryInterface;
+use Magento\SalesRule\Model\ResourceModel\Rule as RuleResource;
+use Magento\SalesRule\Model\RuleFactory as RuleFactory;
+use Magento\TestFramework\Helper\Bootstrap;
+
+$objectManager = Bootstrap::getObjectManager();
+/** @var RuleRepositoryInterface $ruleRepository */
+$ruleRepository = $objectManager->get(RuleRepositoryInterface::class);
+/** @var RuleResource $ruleResource */
+$ruleResource = $objectManager->get(RuleResource::class);
+/** @var RuleFactory $ruleFactory */
+$ruleFactory = $objectManager->get(RuleFactory::class);
+$salesRule = $ruleFactory->create();
+
+$ruleResource->load($salesRule, '50% Off for all orders', 'name');
+// FIXME: the rule cannot be found for some reason
+if ($salesRule->getRuleId()) {
+    $ruleRepository->deleteById($salesRule->getRuleId());
+}

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/cart_rule_discount_no_coupon_rollback.php
@@ -6,21 +6,16 @@
 declare(strict_types=1);
 
 use Magento\SalesRule\Api\RuleRepositoryInterface;
-use Magento\SalesRule\Model\ResourceModel\Rule as RuleResource;
-use Magento\SalesRule\Model\RuleFactory as RuleFactory;
+use Magento\SalesRule\Model\ResourceModel\Rule\CollectionFactory as RuleCollectionFactory;
 use Magento\TestFramework\Helper\Bootstrap;
 
 $objectManager = Bootstrap::getObjectManager();
 /** @var RuleRepositoryInterface $ruleRepository */
 $ruleRepository = $objectManager->get(RuleRepositoryInterface::class);
-/** @var RuleResource $ruleResource */
-$ruleResource = $objectManager->get(RuleResource::class);
-/** @var RuleFactory $ruleFactory */
-$ruleFactory = $objectManager->get(RuleFactory::class);
-$salesRule = $ruleFactory->create();
+/** @var RuleCollectionFactory  $ruleCollectionFactory */
+$ruleCollectionFactory = $objectManager->get(RuleCollectionFactory::class);
+$ruleCollection = $ruleCollectionFactory->create();
 
-$ruleResource->load($salesRule, '50% Off for all orders', 'name');
-// FIXME: the rule cannot be found for some reason
-if ($salesRule->getRuleId()) {
-    $ruleRepository->deleteById($salesRule->getRuleId());
+foreach ($ruleCollection->getItems() as $rule) {
+    $ruleRepository->deleteById($rule->getRuleId());
 }

--- a/dev/tests/integration/testsuite/Magento/SalesRule/_files/cart_rule_100_percent_off_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/SalesRule/_files/cart_rule_100_percent_off_rollback.php
@@ -5,11 +5,19 @@
  */
 declare(strict_types=1);
 
+use Magento\Framework\Registry;
+use Magento\SalesRule\Api\RuleRepositoryInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+$objectManager = Bootstrap::getObjectManager();
 /** @var Magento\Framework\Registry $registry */
-$registry = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Framework\Registry::class);
+$registry = Bootstrap::getObjectManager()->get(Registry::class);
+/** @var RuleRepositoryInterface $ruleRepository */
+$ruleRepository = $objectManager->get(RuleRepositoryInterface::class);
 
 /** @var Magento\SalesRule\Model\Rule $rule */
-$rule = $registry->registry('cart_rule_100_percent_off');
-if ($rule) {
-    $rule->delete();
+$ruleId = $registry->registry('Magento/SalesRule/_files/cart_rule_100_percent_off');
+
+if ($ruleId) {
+    $ruleRepository->deleteById($ruleId);
 }

--- a/dev/tests/integration/testsuite/Magento/SalesRule/_files/coupon_code_with_wildcard.php
+++ b/dev/tests/integration/testsuite/Magento/SalesRule/_files/coupon_code_with_wildcard.php
@@ -27,6 +27,7 @@ $salesRule->setData(
         'discount_amount' => 5,
         'discount_step' => 0,
         'stop_rules_processing' => 1,
+        'store_labels' => [0 => '5$ fixed discount on whole cart'],
         'website_ids' => [
             $objectManager->get(StoreManagerInterface::class)->getWebsite()->getId(),
         ],


### PR DESCRIPTION
### Description (*)
This PR adds additional information about discount to the shopping cart details. The information contains discount amount and a label of the applied rule(s).

### Fixed Issues (if relevant)
1. #683 : Add discount information to cart

### Manual testing scenarios (*)
1. Create a shopping cart price rule
2. Add product to the shopping cart and use cart response for getting he information

```graphql
mutation {
  addSimpleProductsToCart(input: {
    cart_id:"X9KeOSMZuU10yww2S1A4DXfEwFpg0Q9X"
    cart_items: [
      {
        data: {
          quantity:1
          sku:"simle"
        }
      }
    ]
  })
  {
    cart {
      prices {
        discount {
          amount {
            value
            currency
          }
          label
        }
      }
    }
  }
}
```

or use cart query for an existing cart with a product and discount:

```graphql
{
  cart (cart_id:"X9KeOSMZuU10yww2S1A4DXfEwFpg0Q9X") {
    prices {
      discount {
        label
        amount {
          value
          currency
        }
      }
    }
  }
}
```

