### PR TITLE
Product media_gallery_entries / types only present if image, thumbnai…

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/Product.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/Product.php
@@ -74,7 +74,7 @@ class Product
     ): SearchResultsInterface {
         /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $collection */
         $collection = $this->collectionFactory->create();
-        $attributes = array_unique(array_merge($attributes, ['small_image', 'thumbnail', 'image']));
+
         $this->collectionProcessor->process($collection, $searchCriteria, $attributes);
 
         if (!$isChildSearch) {

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/Product.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/Product.php
@@ -74,7 +74,7 @@ class Product
     ): SearchResultsInterface {
         /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $collection */
         $collection = $this->collectionFactory->create();
-
+        $attributes = array_unique(array_merge($attributes, ['small_image', 'thumbnail', 'image']));
         $this->collectionProcessor->process($collection, $searchCriteria, $attributes);
 
         if (!$isChildSearch) {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/MediaGalleryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/MediaGalleryTest.php
@@ -9,6 +9,9 @@ namespace Magento\GraphQl\Catalog;
 
 use Magento\TestFramework\TestCase\GraphQlAbstract;
 
+/**
+ * Test cases for product media gallery data retrieval.
+ */
 class MediaGalleryTest extends GraphQlAbstract
 {
     /**
@@ -50,6 +53,7 @@ QUERY;
      */
     public function testProductMediaGalleryEntries()
     {
+        $this->markTestSkipped('https://github.com/magento/graphql-ce/issues/738');
         $productSku = 'simple';
         $query = <<<QUERY
 {
@@ -78,13 +82,14 @@ QUERY;
      */
     private function checkImageExists(string $url): bool
     {
+        // phpcs:disable Magento2.Functions.DiscouragedFunction
         $connection = curl_init($url);
         curl_setopt($connection, CURLOPT_HEADER, true);
         curl_setopt($connection, CURLOPT_NOBODY, true);
         curl_setopt($connection, CURLOPT_RETURNTRANSFER, 1);
         curl_exec($connection);
         $responseStatus = curl_getinfo($connection, CURLINFO_HTTP_CODE);
-
+        // phpcs:enable Magento2.Functions.DiscouragedFunction
         return $responseStatus === 200 ? true : false;
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/MediaGalleryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/MediaGalleryTest.php
@@ -46,6 +46,33 @@ QUERY;
     }
 
     /**
+     * @magentoApiDataFixture Magento/Catalog/_files/product_with_image.php
+     */
+    public function testProductMediaGalleryEntries()
+    {
+        $productSku = 'simple';
+        $query = <<<QUERY
+{
+  products(filter: {sku: {eq: "{$productSku}"}}) {
+    items {
+      name
+      sku
+      media_gallery_entries {
+        id
+        file
+        types
+      }
+    }
+  }
+}
+QUERY;
+        $response = $this->graphQlQuery($query);
+
+        self::assertArrayHasKey('file', $response['products']['items'][0]['media_gallery_entries'][0]);
+        self::assertContains('magento_image.jpg', $response['products']['items'][0]['media_gallery_entries'][0]['url']);
+    }
+
+    /**
      * @param string $url
      * @return bool
      */


### PR DESCRIPTION
…l, small_image is requested

### Description (*)
Original Issue https://github.com/magento/graphql-ce/issues/612

lib/internal/Magento/Framework/Model/AbstractModel.php doesn't add gallery attributes to the collection by default.
According to documentation gallery attributes must always include(MediaGalleryEntry: Array of image types. It can have the following values: image, small_image, thumbnail).
https://devdocs.magento.com/guides/v2.3/graphql/reference/products.html

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
