### PR TITLE
url_path is not working as documented

### DIFF
--- a/app/code/Magento/CatalogUrlRewriteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogUrlRewriteGraphQl/etc/schema.graphqls
@@ -3,18 +3,18 @@
 
 interface ProductInterface {
     url_key: String @doc(description: "The part of the URL that identifies the product")
-    url_path: String @doc(description: "The part of the URL that precedes the url_key")
+    url_path: String @deprecated(reason: "Use product's `canonical_url` or url rewrites instead")
     url_rewrites: [UrlRewrite] @doc(description: "URL rewrites list") @resolver(class: "Magento\\UrlRewriteGraphQl\\Model\\Resolver\\UrlRewrite")
 }
 
 input ProductFilterInput {
     url_key: FilterTypeInput @doc(description: "The part of the URL that identifies the product")
-    url_path: FilterTypeInput @doc(description: "The part of the URL that precedes the url_key")
+    url_path: FilterTypeInput @deprecated(reason: "Use product's `canonical_url` or url rewrites instead")
 }
 
 input ProductSortInput {
     url_key: SortEnum @doc(description: "The part of the URL that identifies the product")
-    url_path: SortEnum @doc(description: "The part of the URL that precedes the url_key")
+    url_path: SortEnum @deprecated(reason: "Use product's `canonical_url` or url rewrites instead")
 }
 
 enum UrlRewriteEntityTypeEnum @doc(description: "This enumeration defines the entity type.") {


### PR DESCRIPTION
### Description (*)
Original Issue https://github.com/magento/graphql-ce/issues/713

### Fixed Issues (if relevant)
Fix based on https://github.com/magento/magento2/issues/9113

But according to comment of sdzhepa
_url_path is deprecated._

@naydav
Maybe the better solution is to remove this field from documentation and schema in graphql.
Could you clarify?

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
