### PR TITLE
Fix typo: resolve() -> resolver()

### DIFF
--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -118,7 +118,7 @@ type CustomizableAreaValue @doc(description: "CustomizableAreaValue defines the 
 }
 
 type CategoryTree implements CategoryInterface @doc(description: "Category Tree implementation.") {
-    children: [CategoryTree] @doc(description: "Child categories tree.") @resolve(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\CategoryTree")
+    children: [CategoryTree] @doc(description: "Child categories tree.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\CategoryTree")
 }
 
 type CustomizableDateOption implements CustomizableOptionInterface @doc(description: "CustomizableDateOption contains information about a date picker that is defined as part of a customizable option.") {


### PR DESCRIPTION
### Description (*)

This PR fixes a typo in the resolver declaration for  `CategoryTree.children`.
If the field currently can be queried it is resolved by the default resolver, not the specified resolver class `\Magento\CatalogGraphQl\Model\Resolver\CategoryTree`.

Let's see if this breaks any tests...

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
