### PR TITLE
Setting visibility to protected for easier extendability

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Products.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Products.php
@@ -23,17 +23,17 @@ class Products implements ResolverInterface
     /**
      * @var \Magento\Catalog\Api\ProductRepositoryInterface
      */
-    private $productRepository;
+    protected $productRepository;
 
     /**
      * @var Builder
      */
-    private $searchCriteriaBuilder;
+    protected $searchCriteriaBuilder;
 
     /**
      * @var Filter
      */
-    private $filterQuery;
+    protected $filterQuery;
 
     /**
      * @param ProductRepositoryInterface $productRepository

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products.php
@@ -25,22 +25,22 @@ class Products implements ResolverInterface
     /**
      * @var Builder
      */
-    private $searchCriteriaBuilder;
+    protected $searchCriteriaBuilder;
 
     /**
      * @var Search
      */
-    private $searchQuery;
+    protected $searchQuery;
 
     /**
      * @var Filter
      */
-    private $filterQuery;
+    protected $filterQuery;
 
     /**
      * @var SearchFilter
      */
-    private $searchFilter;
+    protected $searchFilter;
 
     /**
      * @param Builder $searchCriteriaBuilder

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/CategoryTree.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/CategoryTree.php
@@ -31,27 +31,27 @@ class CategoryTree
     /**
      * @var CollectionFactory
      */
-    private $collectionFactory;
+    protected $collectionFactory;
 
     /**
      * @var AttributesJoiner
      */
-    private $attributesJoiner;
+    protected $attributesJoiner;
 
     /**
      * @var DepthCalculator
      */
-    private $depthCalculator;
+    protected $depthCalculator;
 
     /**
      * @var LevelCalculator
      */
-    private $levelCalculator;
+    protected $levelCalculator;
 
     /**
      * @var MetadataPool
      */
-    private $metadata;
+    protected $metadata;
 
     /**
      * @param CollectionFactory $collectionFactory
@@ -126,7 +126,7 @@ class CategoryTree
      * @param FieldNode $fieldNode
      * @return void
      */
-    private function joinAttributesRecursively(Collection $collection, FieldNode $fieldNode) : void
+    protected function joinAttributesRecursively(Collection $collection, FieldNode $fieldNode) : void
     {
         if (!isset($fieldNode->selectionSet->selections)) {
             return;

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/Product.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/Product.php
@@ -22,22 +22,22 @@ class Product
     /**
      * @var CollectionFactory
      */
-    private $collectionFactory;
+    protected $collectionFactory;
 
     /**
      * @var ProductSearchResultsInterfaceFactory
      */
-    private $searchResultsFactory;
+    protected $searchResultsFactory;
 
     /**
      * @var CollectionProcessorInterface
      */
-    private $collectionProcessor;
+    protected $collectionProcessor;
 
     /**
      * @var Visibility
      */
-    private $visibility;
+    protected $visibility;
 
     /**
      * @param CollectionFactory $collectionFactory

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/Query/Filter.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/Query/Filter.php
@@ -22,22 +22,22 @@ class Filter
     /**
      * @var SearchResultFactory
      */
-    private $searchResultFactory;
+    protected $searchResultFactory;
 
     /**
      * @var \Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product
      */
-    private $productDataProvider;
+    protected $productDataProvider;
 
     /**
      * @var FieldTranslator
      */
-    private $fieldTranslator;
+    protected $fieldTranslator;
 
     /**
      * @var \Magento\Catalog\Model\Layer\Resolver
      */
-    private $layerResolver;
+    protected $layerResolver;
 
     /**
      * @param SearchResultFactory $searchResultFactory
@@ -88,7 +88,7 @@ class Filter
      * @param ResolveInfo $info
      * @return string[]
      */
-    private function getProductFields(ResolveInfo $info) : array
+    protected function getProductFields(ResolveInfo $info) : array
     {
         $fieldNames = [];
         foreach ($info->fieldNodes as $node) {

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/Query/Search.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/Query/Search.php
@@ -22,32 +22,32 @@ class Search
     /**
      * @var SearchInterface
      */
-    private $search;
+    protected $search;
 
     /**
      * @var FilterHelper
      */
-    private $filterHelper;
+    protected $filterHelper;
 
     /**
      * @var Filter
      */
-    private $filterQuery;
+    protected $filterQuery;
 
     /**
      * @var SearchResultFactory
      */
-    private $searchResultFactory;
+    protected $searchResultFactory;
 
     /**
      * @var \Magento\Framework\EntityManager\MetadataPool
      */
-    private $metadataPool;
+    protected $metadataPool;
 
     /**
      * @var \Magento\Search\Model\Search\PageSizeProvider
      */
-    private $pageSizeProvider;
+    protected $pageSizeProvider;
 
     /**
      * @param SearchInterface $search
@@ -137,7 +137,7 @@ class Search
      * @param SearchCriteriaInterface $searchCriteria
      * @return int[]
      */
-    private function paginateList(SearchResult $searchResult, SearchCriteriaInterface $searchCriteria) : array
+    protected function paginateList(SearchResult $searchResult, SearchCriteriaInterface $searchCriteria) : array
     {
         $length = $searchCriteria->getPageSize();
         // Search starts pages from 0

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/SearchResult.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/SearchResult.php
@@ -17,12 +17,12 @@ class SearchResult
     /**
      * @var SearchResultsInterface
      */
-    private $totalCount;
+    protected $totalCount;
 
     /**
      * @var array
      */
-    private $productsSearchResult;
+    protected $productsSearchResult;
 
     /**
      * @param int $totalCount

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/SearchResultFactory.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/SearchResultFactory.php
@@ -17,7 +17,7 @@ class SearchResultFactory
     /**
      * @var ObjectManagerInterface
      */
-    private $objectManager;
+    protected $objectManager;
 
     /**
      * @param ObjectManagerInterface $objectManager

--- a/app/code/Magento/CmsGraphQl/Model/Resolver/Blocks.php
+++ b/app/code/Magento/CmsGraphQl/Model/Resolver/Blocks.php
@@ -23,7 +23,7 @@ class Blocks implements ResolverInterface
     /**
      * @var BlockDataProvider
      */
-    private $blockDataProvider;
+    protected $blockDataProvider;
 
     /**
      * @param BlockDataProvider $blockDataProvider
@@ -61,7 +61,7 @@ class Blocks implements ResolverInterface
      * @return string[]
      * @throws GraphQlInputException
      */
-    private function getBlockIdentifiers(array $args): array
+    protected function getBlockIdentifiers(array $args): array
     {
         if (!isset($args['identifiers']) || !is_array($args['identifiers']) || count($args['identifiers']) === 0) {
             throw new GraphQlInputException(__('"identifiers" of CMS blocks should be specified'));
@@ -77,7 +77,7 @@ class Blocks implements ResolverInterface
      * @return array
      * @throws GraphQlNoSuchEntityException
      */
-    private function getBlocksData(array $blockIdentifiers): array
+    protected function getBlocksData(array $blockIdentifiers): array
     {
         $blocksData = [];
         foreach ($blockIdentifiers as $blockIdentifier) {

--- a/app/code/Magento/CmsGraphQl/Model/Resolver/DataProvider/Block.php
+++ b/app/code/Magento/CmsGraphQl/Model/Resolver/DataProvider/Block.php
@@ -20,12 +20,12 @@ class Block
     /**
      * @var BlockRepositoryInterface
      */
-    private $blockRepository;
+    protected $blockRepository;
 
     /**
      * @var FilterEmulate
      */
-    private $widgetFilter;
+    protected $widgetFilter;
 
     /**
      * @param BlockRepositoryInterface $blockRepository

--- a/app/code/Magento/CmsGraphQl/Model/Resolver/DataProvider/Page.php
+++ b/app/code/Magento/CmsGraphQl/Model/Resolver/DataProvider/Page.php
@@ -22,22 +22,22 @@ class Page
     /**
      * @var GetPageByIdentifierInterface
      */
-    private $pageByIdentifier;
+    protected $pageByIdentifier;
 
     /**
      * @var PageRepositoryInterface
      */
-    private $pageRepository;
+    protected $pageRepository;
 
     /**
      * @var StoreManagerInterface
      */
-    private $storeManager;
+    protected $storeManager;
 
     /**
      * @var FilterEmulate
      */
-    private $widgetFilter;
+    protected $widgetFilter;
 
     /**
      * @param PageRepositoryInterface $pageRepository
@@ -94,7 +94,7 @@ class Page
      * @return array
      * @throws NoSuchEntityException
      */
-    private function convertPageData(PageInterface $page)
+    protected function convertPageData(PageInterface $page)
     {
         if (false === $page->isActive()) {
             throw new NoSuchEntityException();

--- a/app/code/Magento/CmsGraphQl/Model/Resolver/Page.php
+++ b/app/code/Magento/CmsGraphQl/Model/Resolver/Page.php
@@ -23,7 +23,7 @@ class Page implements ResolverInterface
     /**
      * @var PageDataProvider
      */
-    private $pageDataProvider;
+    protected $pageDataProvider;
 
     /**
      *

--- a/app/code/Magento/StoreGraphQl/Model/Resolver/Store/StoreConfigDataProvider.php
+++ b/app/code/Magento/StoreGraphQl/Model/Resolver/Store/StoreConfigDataProvider.php
@@ -20,22 +20,22 @@ class StoreConfigDataProvider
     /**
      * @var StoreConfigManagerInterface
      */
-    private $storeConfigManager;
+    protected $storeConfigManager;
 
     /**
      * @var StoreManagerInterface
      */
-    private $storeManager;
+    protected $storeManager;
 
     /**
      * @var ScopeConfigInterface
      */
-    private $scopeConfig;
+    protected $scopeConfig;
 
     /**
      * @var array
      */
-    private $extendedConfigData;
+    protected $extendedConfigData;
 
     /**
      * @param StoreConfigManagerInterface $storeConfigManager
@@ -74,7 +74,7 @@ class StoreConfigDataProvider
      *
      * @return array
      */
-    private function getBaseConfigData() : array
+    protected function getBaseConfigData() : array
     {
         $store = $this->storeManager->getStore();
         $storeConfig = current($this->storeConfigManager->getStoreConfigs([$store->getCode()]));
@@ -105,7 +105,7 @@ class StoreConfigDataProvider
      *
      * @return array
      */
-    private function getExtendedConfigData()
+    protected function getExtendedConfigData()
     {
         $store = $this->storeManager->getStore();
         $extendedConfigData = [];


### PR DESCRIPTION
### Description (*)
Setting visibility to `protected` to make different graph ql classes easier to extend while creating customer specific adjustments or customizations.

Current visibility of `private` forces us to copy the whole class and that makes custom code unnecessary large and hard to read and update.

If conceptual move from `private` to `protected` is acceptable, I can adjust this PR with changes in other classes as well. 

### Manual testing scenarios (*)
There are no changes to the functionality

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
