### PR TITLE
Fedex Soap Mock

### DIFF
--- a/dev/tests/api-functional/_files/Magento/TestModuleFedex/Model/MockResponseBodyLoader.php
+++ b/dev/tests/api-functional/_files/Magento/TestModuleFedex/Model/MockResponseBodyLoader.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\TestModuleFedex\Model;
+
+use Magento\Framework\Exception\NotFoundException;
+use Magento\Framework\HTTP\AsyncClient\Request;
+use Magento\Framework\Module\Dir;
+use Magento\Framework\Filesystem\Io\File;
+use Magento\Framework\Stdlib\ArrayManager;
+
+/**
+ * Load mock response body for Fedex rate request
+ */
+class MockResponseBodyLoader
+{
+    private const RESPONSE_FILE_PATTERN = '%s/_files/mock_response_%s_%s.json';
+    private const PATH_COUNTRY = 'RequestedShipment/Recipient/Address/CountryCode';
+    private const PATH_SERVICE_TYPE = 'RequestedShipment/ServiceType';
+
+    /**
+     * @var Dir
+     */
+    private $moduleDirectory;
+
+    /**
+     * @var File
+     */
+    private $fileIo;
+
+    /**
+     * @var ArrayManager
+     */
+    private $arrayManager;
+
+    /**
+     * @param Dir $moduleDirectory
+     * @param File $fileIo
+     * @param ArrayManager
+     */
+    public function __construct(
+        Dir $moduleDirectory,
+        File $fileIo,
+        ArrayManager $arrayManager
+    ) {
+        $this->moduleDirectory = $moduleDirectory;
+        $this->fileIo = $fileIo;
+        $this->arrayManager = $arrayManager;
+    }
+
+    /**
+     * Loads mock response xml for a given request
+     *
+     * @param array $request
+     * @return string
+     * @throws NotFoundException
+     */
+    public function loadForRequest(array $request): string
+    {
+        $moduleDir = $this->moduleDirectory->getDir('Magento_TestModuleFedex');
+
+        $type = strtolower($this->arrayManager->get(static::PATH_SERVICE_TYPE, $request) ?? 'general');
+        $country = strtolower($this->arrayManager->get(static::PATH_COUNTRY, $request) ?? '');
+
+        $responsePath = sprintf(static::RESPONSE_FILE_PATTERN, $moduleDir, $type, $country);
+
+        if (!$this->fileIo->fileExists($responsePath)) {
+            throw new NotFoundException(
+                __('"%1" is not a valid mock response type for country "%2".', $type, $country)
+            );
+        }
+
+        return $this->fileIo->read($responsePath);
+    }
+}

--- a/dev/tests/api-functional/_files/Magento/TestModuleFedex/Model/MockSoapClient.php
+++ b/dev/tests/api-functional/_files/Magento/TestModuleFedex/Model/MockSoapClient.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\TestModuleFedex\Model;
+
+/**
+ * Mock Fedex soap client factory
+ */
+class MockSoapClient extends \SoapClient
+{
+    /**
+     * @var MockResponseBodyLoader
+     */
+    private $mockResponseBodyLoader;
+
+    /**
+     * @param string $wsdl
+     * @param MockResponseBodyLoader $mockResponseBodyLoader
+     * @param array|null $options
+     */
+    public function __construct(
+        string $wsdl,
+        MockResponseBodyLoader $mockResponseBodyLoader,
+        array $options = null
+    ) {
+        parent::__construct($wsdl, $options);
+        $this->mockResponseBodyLoader = $mockResponseBodyLoader;
+    }
+
+    /**
+     * Fetch mock Fedex rates
+     *
+     * @param array $rateRequest
+     * @return \stdClass
+     * @throws \Magento\Framework\Exception\NotFoundException
+     */
+    public function getRates(array $rateRequest): \stdClass
+    {
+        $response = $this->mockResponseBodyLoader->loadForRequest($rateRequest);
+
+        return json_decode($response);
+    }
+}

--- a/dev/tests/api-functional/_files/Magento/TestModuleFedex/Model/MockSoapClientFactory.php
+++ b/dev/tests/api-functional/_files/Magento/TestModuleFedex/Model/MockSoapClientFactory.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\TestModuleFedex\Model;
+
+use Magento\Framework\App\ObjectManager;
+
+/**
+ * Mock Fedex soap client factory
+ */
+class MockSoapClientFactory extends \Magento\Framework\Webapi\Soap\ClientFactory
+{
+    /**
+     * Create instance of the mock SoapClient
+     *
+     * @param string $wsdl
+     * @param array $options
+     * @return \SoapClient
+     */
+    public function create($wsdl, array $options = []): \SoapClient
+    {
+        return ObjectManager::getInstance()->create(
+            MockSoapClient::class,
+            [
+                'wsdl' => $wsdl,
+                'options' => $options,
+            ]
+        );
+    }
+}

--- a/dev/tests/api-functional/_files/Magento/TestModuleFedex/_files/mock_response_general_ca.json
+++ b/dev/tests/api-functional/_files/Magento/TestModuleFedex/_files/mock_response_general_ca.json
@@ -1,0 +1,912 @@
+{
+  "HighestSeverity": "NOTE",
+  "Notifications": [
+    {
+      "Severity": "NOTE",
+      "Source": "crs",
+      "Code": "886",
+      "Message": "Money Back Guarantee is not eligible for this pick up\/delivery postal\/zip code. FDXG",
+      "LocalizedMessage": "Money Back Guarantee is not eligible for this pick up\/delivery postal\/zip code. FDXG",
+      "MessageParameters": {
+        "Id": "OPERATING_COMPANY",
+        "Value": "FDXG"
+      }
+    },
+    {
+      "Severity": "NOTE",
+      "Source": "crs",
+      "Code": "819",
+      "Message": "The origin state\/province code has been changed.  ",
+      "LocalizedMessage": "The origin state\/province code has been changed.  "
+    },
+    {
+      "Severity": "NOTE",
+      "Source": "crs",
+      "Code": "820",
+      "Message": "The destination state\/province code has been changed.  ",
+      "LocalizedMessage": "The destination state\/province code has been changed.  "
+    }
+  ],
+  "Version": {
+    "ServiceId": "crs",
+    "Major": 10,
+    "Intermediate": 0,
+    "Minor": 0
+  },
+  "RateReplyDetails": [
+    {
+      "ServiceType": "INTERNATIONAL_PRIORITY",
+      "PackagingType": "YOUR_PACKAGING",
+      "DestinationAirportId": "YYZ",
+      "IneligibleForMoneyBackGuarantee": false,
+      "OriginServiceArea": "A1",
+      "DestinationServiceArea": "AM",
+      "SignatureOption": "SERVICE_DEFAULT",
+      "ActualRateType": "PAYOR_ACCOUNT_SHIPMENT",
+      "RatedShipmentDetails": [
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_ACCOUNT_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.65"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.65"
+              }
+            }
+          }
+        },
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "RATED_ACCOUNT_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.65"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.65"
+              }
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_LIST_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.65"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.65"
+              }
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "RATED_LIST_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.65"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.65"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "ServiceType": "INTERNATIONAL_ECONOMY",
+      "PackagingType": "YOUR_PACKAGING",
+      "DestinationAirportId": "YYZ",
+      "IneligibleForMoneyBackGuarantee": false,
+      "OriginServiceArea": "A1",
+      "DestinationServiceArea": "AM",
+      "SignatureOption": "SERVICE_DEFAULT",
+      "ActualRateType": "PAYOR_ACCOUNT_SHIPMENT",
+      "RatedShipmentDetails": [
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_ACCOUNT_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.16"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.16"
+              }
+            }
+          }
+        },
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "RATED_ACCOUNT_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.16"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.16"
+              }
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_LIST_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.16"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.16"
+              }
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "RATED_LIST_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.16"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.16"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "ServiceType": "FEDEX_GROUND",
+      "PackagingType": "YOUR_PACKAGING",
+      "DestinationAirportId": "YYZ",
+      "IneligibleForMoneyBackGuarantee": true,
+      "SignatureOption": "SERVICE_DEFAULT",
+      "ActualRateType": "PAYOR_ACCOUNT_PACKAGE",
+      "RatedShipmentDetails": [
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_ACCOUNT_PACKAGE",
+            "RateZone": "51",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "7.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "22.73"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "22.73"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "1.59"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "24.32"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "24.32"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "24.32"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Level": "PACKAGE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Level": "PACKAGE",
+                "Description": "FedEx Ground Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "1.59"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "EffectiveNetDiscount": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "PackageRateDetail": {
+              "RateType": "PAYOR_ACCOUNT_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "22.73"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "22.73"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "1.59"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "24.32"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "24.32"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Level": "PACKAGE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Level": "PACKAGE",
+                  "Description": "FedEx Ground Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "1.59"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_LIST_PACKAGE",
+            "RateZone": "51",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "7.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "22.73"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "22.73"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "1.59"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "24.32"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "24.32"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "24.32"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Level": "PACKAGE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Level": "PACKAGE",
+                "Description": "FedEx Ground Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "1.59"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "PackageRateDetail": {
+              "RateType": "PAYOR_LIST_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "22.73"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "22.73"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "1.59"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "24.32"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "24.32"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Level": "PACKAGE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Level": "PACKAGE",
+                  "Description": "FedEx Ground Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "1.59"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/dev/tests/api-functional/_files/Magento/TestModuleFedex/_files/mock_response_general_us.json
+++ b/dev/tests/api-functional/_files/Magento/TestModuleFedex/_files/mock_response_general_us.json
@@ -1,0 +1,2870 @@
+{
+  "HighestSeverity": "WARNING",
+  "Notifications": [
+    {
+      "Severity": "WARNING",
+      "Source": "crs",
+      "Code": "835",
+      "Message": "Destination Postal-City Mismatch. ",
+      "LocalizedMessage": "Destination Postal-City Mismatch. "
+    },
+    {
+      "Severity": "NOTE",
+      "Source": "crs",
+      "Code": "819",
+      "Message": "The origin state\/province code has been changed.  ",
+      "LocalizedMessage": "The origin state\/province code has been changed.  "
+    },
+    {
+      "Severity": "NOTE",
+      "Source": "crs",
+      "Code": "820",
+      "Message": "The destination state\/province code has been changed.  ",
+      "LocalizedMessage": "The destination state\/province code has been changed.  "
+    }
+  ],
+  "Version": {
+    "ServiceId": "crs",
+    "Major": 10,
+    "Intermediate": 0,
+    "Minor": 0
+  },
+  "RateReplyDetails": [
+    {
+      "ServiceType": "FIRST_OVERNIGHT",
+      "PackagingType": "YOUR_PACKAGING",
+      "DestinationAirportId": "DFW",
+      "IneligibleForMoneyBackGuarantee": false,
+      "OriginServiceArea": "A1",
+      "DestinationServiceArea": "A6",
+      "SignatureOption": "SERVICE_DEFAULT",
+      "ActualRateType": "PAYOR_ACCOUNT_PACKAGE",
+      "RatedShipmentDetails": [
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_ACCOUNT_PACKAGE",
+            "RateScale": "14",
+            "RateZone": "6",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "102.59"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "102.59"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "9.18"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "111.77"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "111.77"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "111.77"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "6.33"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "EffectiveNetDiscount": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "PackageRateDetail": {
+              "RateType": "PAYOR_ACCOUNT_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "102.59"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "102.59"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "9.18"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "111.77"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "111.77"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "6.33"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "RATED_ACCOUNT_PACKAGE",
+            "RateScale": "14",
+            "RateZone": "6",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "102.59"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "102.59"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "9.18"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "111.77"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "111.77"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "111.77"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "6.33"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "EffectiveNetDiscount": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "PackageRateDetail": {
+              "RateType": "RATED_ACCOUNT_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "102.59"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "102.59"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "9.18"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "111.77"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "111.77"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "6.33"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_LIST_PACKAGE",
+            "RateScale": "14",
+            "RateZone": "6",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "102.59"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "102.59"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "9.18"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "111.77"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "111.77"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "111.77"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "6.33"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "PackageRateDetail": {
+              "RateType": "PAYOR_LIST_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "102.59"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "102.59"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "9.18"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "111.77"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "111.77"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "6.33"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "RATED_LIST_PACKAGE",
+            "RateScale": "14",
+            "RateZone": "6",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "102.59"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "102.59"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "9.18"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "111.77"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "111.77"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "111.77"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "6.33"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "PackageRateDetail": {
+              "RateType": "RATED_LIST_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "102.59"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "102.59"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "9.18"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "111.77"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "111.77"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "6.33"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "ServiceType": "PRIORITY_OVERNIGHT",
+      "PackagingType": "YOUR_PACKAGING",
+      "DestinationAirportId": "DFW",
+      "IneligibleForMoneyBackGuarantee": false,
+      "OriginServiceArea": "A1",
+      "DestinationServiceArea": "A6",
+      "SignatureOption": "SERVICE_DEFAULT",
+      "ActualRateType": "PAYOR_ACCOUNT_PACKAGE",
+      "RatedShipmentDetails": [
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "49.92"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_ACCOUNT_PACKAGE",
+            "RateScale": "1",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "25.5"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "25.5"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.55"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "30.05"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "30.05"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "30.05"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "1.7"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "EffectiveNetDiscount": {
+              "Currency": "USD",
+              "Amount": "49.92"
+            },
+            "PackageRateDetail": {
+              "RateType": "PAYOR_ACCOUNT_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "25.5"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "25.5"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "4.55"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "30.05"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "30.05"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "1.7"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "49.92"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "RATED_ACCOUNT_PACKAGE",
+            "RateScale": "1",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "25.5"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "25.5"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.55"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "30.05"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "30.05"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "30.05"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "1.7"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "EffectiveNetDiscount": {
+              "Currency": "USD",
+              "Amount": "49.92"
+            },
+            "PackageRateDetail": {
+              "RateType": "RATED_ACCOUNT_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "25.5"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "25.5"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "4.55"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "30.05"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "30.05"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "1.7"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_LIST_PACKAGE",
+            "RateScale": "1574",
+            "RateZone": "6",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "72.59"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "72.59"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "7.38"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "79.97"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "79.97"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "79.97"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "4.53"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "PackageRateDetail": {
+              "RateType": "PAYOR_LIST_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "72.59"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "72.59"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "7.38"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "79.97"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "79.97"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "4.53"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "RATED_LIST_PACKAGE",
+            "RateScale": "1574",
+            "RateZone": "6",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "72.59"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "72.59"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "7.38"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "79.97"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "79.97"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "79.97"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "4.53"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "PackageRateDetail": {
+              "RateType": "RATED_LIST_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "72.59"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "72.59"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "7.38"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "79.97"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "79.97"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "4.53"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "ServiceType": "FEDEX_2_DAY",
+      "PackagingType": "YOUR_PACKAGING",
+      "DestinationAirportId": "DFW",
+      "IneligibleForMoneyBackGuarantee": false,
+      "OriginServiceArea": "A1",
+      "DestinationServiceArea": "A6",
+      "SignatureOption": "SERVICE_DEFAULT",
+      "ActualRateType": "PAYOR_ACCOUNT_PACKAGE",
+      "RatedShipmentDetails": [
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_ACCOUNT_PACKAGE",
+            "RateScale": "6068",
+            "RateZone": "6",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "30.8"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "30.8"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.87"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "35.67"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "35.67"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "35.67"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.02"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "EffectiveNetDiscount": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "PackageRateDetail": {
+              "RateType": "PAYOR_ACCOUNT_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "30.8"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "30.8"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "4.87"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "35.67"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "35.67"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.02"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "RATED_ACCOUNT_PACKAGE",
+            "RateScale": "6068",
+            "RateZone": "6",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "30.8"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "30.8"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.87"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "35.67"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "35.67"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "35.67"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.02"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "EffectiveNetDiscount": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "PackageRateDetail": {
+              "RateType": "RATED_ACCOUNT_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "30.8"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "30.8"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "4.87"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "35.67"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "35.67"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.02"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_LIST_PACKAGE",
+            "RateScale": "6068",
+            "RateZone": "6",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "30.8"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "30.8"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.87"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "35.67"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "35.67"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "35.67"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.02"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "PackageRateDetail": {
+              "RateType": "PAYOR_LIST_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "30.8"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "30.8"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "4.87"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "35.67"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "35.67"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.02"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "RATED_LIST_PACKAGE",
+            "RateScale": "6068",
+            "RateZone": "6",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "30.8"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "30.8"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.87"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "35.67"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "35.67"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "35.67"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.02"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "PackageRateDetail": {
+              "RateType": "RATED_LIST_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "30.8"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "30.8"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "4.87"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "35.67"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "35.67"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.02"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "ServiceType": "FEDEX_EXPRESS_SAVER",
+      "PackagingType": "YOUR_PACKAGING",
+      "DestinationAirportId": "DFW",
+      "IneligibleForMoneyBackGuarantee": false,
+      "OriginServiceArea": "A1",
+      "DestinationServiceArea": "A6",
+      "SignatureOption": "SERVICE_DEFAULT",
+      "ActualRateType": "PAYOR_ACCOUNT_PACKAGE",
+      "RatedShipmentDetails": [
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_ACCOUNT_PACKAGE",
+            "RateScale": "7175",
+            "RateZone": "6",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "22.37"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "22.37"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.36"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "26.73"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "26.73"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "26.73"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "1.51"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "EffectiveNetDiscount": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "PackageRateDetail": {
+              "RateType": "PAYOR_ACCOUNT_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "22.37"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "22.37"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "4.36"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "26.73"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "26.73"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "1.51"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "RATED_ACCOUNT_PACKAGE",
+            "RateScale": "7175",
+            "RateZone": "6",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "22.37"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "22.37"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.36"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "26.73"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "26.73"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "26.73"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "1.51"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "EffectiveNetDiscount": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "PackageRateDetail": {
+              "RateType": "RATED_ACCOUNT_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "22.37"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "22.37"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "4.36"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "26.73"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "26.73"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "1.51"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_LIST_PACKAGE",
+            "RateScale": "7175",
+            "RateZone": "6",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "22.37"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "22.37"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.36"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "26.73"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "26.73"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "26.73"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "1.51"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "PackageRateDetail": {
+              "RateType": "PAYOR_LIST_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "22.37"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "22.37"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "4.36"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "26.73"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "26.73"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "1.51"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "RATED_LIST_PACKAGE",
+            "RateScale": "7175",
+            "RateZone": "6",
+            "PricingCode": "PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "6.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "22.37"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "22.37"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.36"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "26.73"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "26.73"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "26.73"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.85"
+                }
+              },
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Description": "Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "1.51"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "PackageRateDetail": {
+              "RateType": "RATED_LIST_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "22.37"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "22.37"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "4.36"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "26.73"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "26.73"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.85"
+                  }
+                },
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Description": "Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "1.51"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "ServiceType": "FEDEX_GROUND",
+      "PackagingType": "YOUR_PACKAGING",
+      "DestinationAirportId": "DFW",
+      "IneligibleForMoneyBackGuarantee": false,
+      "SignatureOption": "SERVICE_DEFAULT",
+      "ActualRateType": "PAYOR_ACCOUNT_PACKAGE",
+      "RatedShipmentDetails": [
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_ACCOUNT_PACKAGE",
+            "RateZone": "6",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "7.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "10.82"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "10.82"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "3.65"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "14.47"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "14.47"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "14.47"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Level": "PACKAGE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Level": "PACKAGE",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.7"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Level": "PACKAGE",
+                "Description": "FedEx Ground Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.95"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "EffectiveNetDiscount": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "PackageRateDetail": {
+              "RateType": "PAYOR_ACCOUNT_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "10.82"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "10.82"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "3.65"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "14.47"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "14.47"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Level": "PACKAGE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Level": "PACKAGE",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.7"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Level": "PACKAGE",
+                  "Description": "FedEx Ground Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.95"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_LIST_PACKAGE",
+            "RateZone": "6",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "7.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "10.82"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "10.82"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "3.65"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "14.47"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "14.47"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "14.47"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Level": "PACKAGE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Level": "PACKAGE",
+                "Description": "Delivery Area Surcharge Extended Commercial",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "2.7"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Level": "PACKAGE",
+                "Description": "FedEx Ground Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.95"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "PackageRateDetail": {
+              "RateType": "PAYOR_LIST_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "10.82"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "10.82"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "3.65"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "14.47"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "14.47"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Level": "PACKAGE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "DELIVERY_AREA",
+                  "Level": "PACKAGE",
+                  "Description": "Delivery Area Surcharge Extended Commercial",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "2.7"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Level": "PACKAGE",
+                  "Description": "FedEx Ground Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.95"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/dev/tests/api-functional/_files/Magento/TestModuleFedex/_files/mock_response_smart_post_ca.json
+++ b/dev/tests/api-functional/_files/Magento/TestModuleFedex/_files/mock_response_smart_post_ca.json
@@ -1,0 +1,912 @@
+{
+  "HighestSeverity": "NOTE",
+  "Notifications": [
+    {
+      "Severity": "NOTE",
+      "Source": "crs",
+      "Code": "886",
+      "Message": "Money Back Guarantee is not eligible for this pick up\/delivery postal\/zip code. FDXG",
+      "LocalizedMessage": "Money Back Guarantee is not eligible for this pick up\/delivery postal\/zip code. FDXG",
+      "MessageParameters": {
+        "Id": "OPERATING_COMPANY",
+        "Value": "FDXG"
+      }
+    },
+    {
+      "Severity": "NOTE",
+      "Source": "crs",
+      "Code": "819",
+      "Message": "The origin state\/province code has been changed.  ",
+      "LocalizedMessage": "The origin state\/province code has been changed.  "
+    },
+    {
+      "Severity": "NOTE",
+      "Source": "crs",
+      "Code": "820",
+      "Message": "The destination state\/province code has been changed.  ",
+      "LocalizedMessage": "The destination state\/province code has been changed.  "
+    }
+  ],
+  "Version": {
+    "ServiceId": "crs",
+    "Major": 10,
+    "Intermediate": 0,
+    "Minor": 0
+  },
+  "RateReplyDetails": [
+    {
+      "ServiceType": "INTERNATIONAL_PRIORITY",
+      "PackagingType": "YOUR_PACKAGING",
+      "DestinationAirportId": "YYZ",
+      "IneligibleForMoneyBackGuarantee": false,
+      "OriginServiceArea": "A1",
+      "DestinationServiceArea": "AM",
+      "SignatureOption": "SERVICE_DEFAULT",
+      "ActualRateType": "PAYOR_ACCOUNT_SHIPMENT",
+      "RatedShipmentDetails": [
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_ACCOUNT_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.65"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.65"
+              }
+            }
+          }
+        },
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "RATED_ACCOUNT_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.65"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.65"
+              }
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_LIST_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.65"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.65"
+              }
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "RATED_LIST_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "92.99"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.65"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "97.64"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.65"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "ServiceType": "INTERNATIONAL_ECONOMY",
+      "PackagingType": "YOUR_PACKAGING",
+      "DestinationAirportId": "YYZ",
+      "IneligibleForMoneyBackGuarantee": false,
+      "OriginServiceArea": "A1",
+      "DestinationServiceArea": "AM",
+      "SignatureOption": "SERVICE_DEFAULT",
+      "ActualRateType": "PAYOR_ACCOUNT_SHIPMENT",
+      "RatedShipmentDetails": [
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_ACCOUNT_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.16"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.16"
+              }
+            }
+          }
+        },
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "RATED_ACCOUNT_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.16"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.16"
+              }
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_LIST_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.16"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.16"
+              }
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "RATED_LIST_SHIPMENT",
+            "RateScale": "0000000",
+            "RateZone": "US001O",
+            "PricingCode": "ACTUAL",
+            "RatedWeightMethod": "ACTUAL",
+            "CurrencyExchangeRate": {
+              "FromCurrency": "USD",
+              "IntoCurrency": "USD",
+              "Rate": "1.0"
+            },
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "5.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "83.18"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "4.16"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "87.34"
+            },
+            "Surcharges": {
+              "SurchargeType": "FUEL",
+              "Description": "Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "4.16"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "ServiceType": "FEDEX_GROUND",
+      "PackagingType": "YOUR_PACKAGING",
+      "DestinationAirportId": "YYZ",
+      "IneligibleForMoneyBackGuarantee": true,
+      "SignatureOption": "SERVICE_DEFAULT",
+      "ActualRateType": "PAYOR_ACCOUNT_PACKAGE",
+      "RatedShipmentDetails": [
+        {
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_ACCOUNT_PACKAGE",
+            "RateZone": "51",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "7.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "22.73"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "22.73"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "1.59"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "24.32"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "24.32"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "24.32"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Level": "PACKAGE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Level": "PACKAGE",
+                "Description": "FedEx Ground Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "1.59"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "EffectiveNetDiscount": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "PackageRateDetail": {
+              "RateType": "PAYOR_ACCOUNT_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "22.73"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "22.73"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "1.59"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "24.32"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "24.32"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Level": "PACKAGE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Level": "PACKAGE",
+                  "Description": "FedEx Ground Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "1.59"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ShipmentRateDetail": {
+            "RateType": "PAYOR_LIST_PACKAGE",
+            "RateZone": "51",
+            "RatedWeightMethod": "ACTUAL",
+            "DimDivisor": 0,
+            "FuelSurchargePercent": "7.0",
+            "TotalBillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "TotalBaseCharge": {
+              "Currency": "USD",
+              "Amount": "22.73"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetFreight": {
+              "Currency": "USD",
+              "Amount": "22.73"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "1.59"
+            },
+            "TotalNetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "24.32"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetCharge": {
+              "Currency": "USD",
+              "Amount": "24.32"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "TotalNetChargeWithDutiesAndTaxes": {
+              "Currency": "USD",
+              "Amount": "24.32"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "INSURED_VALUE",
+                "Level": "PACKAGE",
+                "Description": "Insured value",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.0"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Level": "PACKAGE",
+                "Description": "FedEx Ground Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "1.59"
+                }
+              }
+            ]
+          },
+          "RatedPackages": {
+            "GroupNumber": 0,
+            "PackageRateDetail": {
+              "RateType": "PAYOR_LIST_PACKAGE",
+              "RatedWeightMethod": "ACTUAL",
+              "BillingWeight": {
+                "Units": "LB",
+                "Value": "2.0"
+              },
+              "BaseCharge": {
+                "Currency": "USD",
+                "Amount": "22.73"
+              },
+              "TotalFreightDiscounts": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetFreight": {
+                "Currency": "USD",
+                "Amount": "22.73"
+              },
+              "TotalSurcharges": {
+                "Currency": "USD",
+                "Amount": "1.59"
+              },
+              "NetFedExCharge": {
+                "Currency": "USD",
+                "Amount": "24.32"
+              },
+              "TotalTaxes": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "NetCharge": {
+                "Currency": "USD",
+                "Amount": "24.32"
+              },
+              "TotalRebates": {
+                "Currency": "USD",
+                "Amount": "0.0"
+              },
+              "Surcharges": [
+                {
+                  "SurchargeType": "INSURED_VALUE",
+                  "Level": "PACKAGE",
+                  "Description": "Insured value",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "0.0"
+                  }
+                },
+                {
+                  "SurchargeType": "FUEL",
+                  "Level": "PACKAGE",
+                  "Description": "FedEx Ground Fuel",
+                  "Amount": {
+                    "Currency": "USD",
+                    "Amount": "1.59"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/dev/tests/api-functional/_files/Magento/TestModuleFedex/_files/mock_response_smart_post_us.json
+++ b/dev/tests/api-functional/_files/Magento/TestModuleFedex/_files/mock_response_smart_post_us.json
@@ -1,0 +1,305 @@
+{
+  "HighestSeverity": "SUCCESS",
+  "Notifications": {
+    "Severity": "SUCCESS",
+    "Source": "crs",
+    "Code": "0",
+    "Message": "Request was successfully processed. ",
+    "LocalizedMessage": "Request was successfully processed. "
+  },
+  "Version": {
+    "ServiceId": "crs",
+    "Major": 10,
+    "Intermediate": 0,
+    "Minor": 0
+  },
+  "RateReplyDetails": {
+    "ServiceType": "SMART_POST",
+    "PackagingType": "YOUR_PACKAGING",
+    "IneligibleForMoneyBackGuarantee": false,
+    "SignatureOption": "SERVICE_DEFAULT",
+    "ActualRateType": "PAYOR_ACCOUNT_PACKAGE",
+    "RatedShipmentDetails": [
+      {
+        "EffectiveNetDiscount": {
+          "Currency": "USD",
+          "Amount": "1.91"
+        },
+        "ShipmentRateDetail": {
+          "RateType": "PAYOR_ACCOUNT_PACKAGE",
+          "RateZone": "6",
+          "RatedWeightMethod": "ACTUAL",
+          "DimDivisor": 0,
+          "FuelSurchargePercent": "7.0",
+          "TotalBillingWeight": {
+            "Units": "LB",
+            "Value": "2.0"
+          },
+          "TotalBaseCharge": {
+            "Currency": "USD",
+            "Amount": "9.49"
+          },
+          "TotalFreightDiscounts": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "TotalNetFreight": {
+            "Currency": "USD",
+            "Amount": "9.49"
+          },
+          "TotalSurcharges": {
+            "Currency": "USD",
+            "Amount": "2.27"
+          },
+          "TotalNetFedExCharge": {
+            "Currency": "USD",
+            "Amount": "11.76"
+          },
+          "TotalTaxes": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "TotalNetCharge": {
+            "Currency": "USD",
+            "Amount": "11.76"
+          },
+          "TotalRebates": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "TotalDutiesAndTaxes": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "TotalNetChargeWithDutiesAndTaxes": {
+            "Currency": "USD",
+            "Amount": "11.76"
+          },
+          "Surcharges": [
+            {
+              "SurchargeType": "DELIVERY_AREA",
+              "Level": "PACKAGE",
+              "Description": "Delivery Area Surcharge Extended",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "1.5"
+              }
+            },
+            {
+              "SurchargeType": "FUEL",
+              "Level": "PACKAGE",
+              "Description": "SmartPost Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "0.77"
+              }
+            }
+          ]
+        },
+        "RatedPackages": {
+          "GroupNumber": 0,
+          "EffectiveNetDiscount": {
+            "Currency": "USD",
+            "Amount": "1.91"
+          },
+          "PackageRateDetail": {
+            "RateType": "PAYOR_ACCOUNT_PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "BillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "BaseCharge": {
+              "Currency": "USD",
+              "Amount": "9.49"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "NetFreight": {
+              "Currency": "USD",
+              "Amount": "9.49"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "2.27"
+            },
+            "NetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "11.76"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "NetCharge": {
+              "Currency": "USD",
+              "Amount": "11.76"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Level": "PACKAGE",
+                "Description": "Delivery Area Surcharge Extended",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "1.5"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Level": "PACKAGE",
+                "Description": "SmartPost Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.77"
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "ShipmentRateDetail": {
+          "RateType": "PAYOR_LIST_PACKAGE",
+          "RateZone": "6",
+          "RatedWeightMethod": "ACTUAL",
+          "DimDivisor": 0,
+          "FuelSurchargePercent": "7.0",
+          "TotalBillingWeight": {
+            "Units": "LB",
+            "Value": "2.0"
+          },
+          "TotalBaseCharge": {
+            "Currency": "USD",
+            "Amount": "10.82"
+          },
+          "TotalFreightDiscounts": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "TotalNetFreight": {
+            "Currency": "USD",
+            "Amount": "10.82"
+          },
+          "TotalSurcharges": {
+            "Currency": "USD",
+            "Amount": "2.85"
+          },
+          "TotalNetFedExCharge": {
+            "Currency": "USD",
+            "Amount": "13.67"
+          },
+          "TotalTaxes": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "TotalNetCharge": {
+            "Currency": "USD",
+            "Amount": "13.67"
+          },
+          "TotalRebates": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "TotalDutiesAndTaxes": {
+            "Currency": "USD",
+            "Amount": "0.0"
+          },
+          "TotalNetChargeWithDutiesAndTaxes": {
+            "Currency": "USD",
+            "Amount": "13.67"
+          },
+          "Surcharges": [
+            {
+              "SurchargeType": "DELIVERY_AREA",
+              "Level": "PACKAGE",
+              "Description": "Delivery Area Surcharge Extended",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "1.95"
+              }
+            },
+            {
+              "SurchargeType": "FUEL",
+              "Level": "PACKAGE",
+              "Description": "SmartPost Fuel",
+              "Amount": {
+                "Currency": "USD",
+                "Amount": "0.9"
+              }
+            }
+          ]
+        },
+        "RatedPackages": {
+          "GroupNumber": 0,
+          "PackageRateDetail": {
+            "RateType": "PAYOR_LIST_PACKAGE",
+            "RatedWeightMethod": "ACTUAL",
+            "BillingWeight": {
+              "Units": "LB",
+              "Value": "2.0"
+            },
+            "BaseCharge": {
+              "Currency": "USD",
+              "Amount": "10.82"
+            },
+            "TotalFreightDiscounts": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "NetFreight": {
+              "Currency": "USD",
+              "Amount": "10.82"
+            },
+            "TotalSurcharges": {
+              "Currency": "USD",
+              "Amount": "2.85"
+            },
+            "NetFedExCharge": {
+              "Currency": "USD",
+              "Amount": "13.67"
+            },
+            "TotalTaxes": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "NetCharge": {
+              "Currency": "USD",
+              "Amount": "13.67"
+            },
+            "TotalRebates": {
+              "Currency": "USD",
+              "Amount": "0.0"
+            },
+            "Surcharges": [
+              {
+                "SurchargeType": "DELIVERY_AREA",
+                "Level": "PACKAGE",
+                "Description": "Delivery Area Surcharge Extended",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "1.95"
+                }
+              },
+              {
+                "SurchargeType": "FUEL",
+                "Level": "PACKAGE",
+                "Description": "SmartPost Fuel",
+                "Amount": {
+                  "Currency": "USD",
+                  "Amount": "0.9"
+                }
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/dev/tests/api-functional/_files/Magento/TestModuleFedex/etc/di.xml
+++ b/dev/tests/api-functional/_files/Magento/TestModuleFedex/etc/di.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Fedex\Model\Carrier">
+        <arguments>
+            <argument name="soapClientFactory" xsi:type="object">Magento\TestModuleFedex\Model\MockSoapClientFactory</argument>
+        </arguments>
+    </type>
+</config>

--- a/dev/tests/api-functional/_files/Magento/TestModuleFedex/etc/module.xml
+++ b/dev/tests/api-functional/_files/Magento/TestModuleFedex/etc/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Magento_TestModuleFedex" />
+</config>

--- a/dev/tests/api-functional/_files/Magento/TestModuleFedex/registration.php
+++ b/dev/tests/api-functional/_files/Magento/TestModuleFedex/registration.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+use Magento\Framework\Component\ComponentRegistrar;
+
+$registrar = new ComponentRegistrar();
+if ($registrar->getPath(ComponentRegistrar::MODULE, 'Magento_TestModuleFedex') === null) {
+    ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_TestModuleFedex', __DIR__);
+}

--- a/dev/tests/integration/testsuite/Magento/GraphQl/FedEx/_files/enable_fedex_shipping_method.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/FedEx/_files/enable_fedex_shipping_method.php
@@ -14,26 +14,9 @@ $objectManager = Bootstrap::getObjectManager();
 /** @var Writer $configWriter */
 $configWriter = $objectManager->get(WriterInterface::class);
 
-/** @var $mutableScopeConfig */
-$mutableScopeConfig = $objectManager->get(
-    \Magento\Framework\App\Config\MutableScopeConfigInterface::class
-);
-
-/**
- * Retrieve data from TESTS_GLOBAL_CONFIG_FILE
- */
-$fedexAccount = $mutableScopeConfig->getValue('carriers/fedex/account', 'store');
-$fedexMeterNumber = $mutableScopeConfig->getValue('carriers/fedex/meter_number', 'store');
-$fedexKey = $mutableScopeConfig->getValue('carriers/fedex/key', 'store');
-$fedexPassword = $mutableScopeConfig->getValue('carriers/fedex/password', 'store');
-$fedexEndpointUrl = $mutableScopeConfig->getValue('carriers/fedex/production_webservices_url', 'store');
-
-$configWriter->save('carriers/fedex/active', 1);
-$configWriter->save('carriers/fedex/account', $fedexAccount);
-$configWriter->save('carriers/fedex/meter_number', $fedexMeterNumber);
-$configWriter->save('carriers/fedex/key', $fedexKey);
-$configWriter->save('carriers/fedex/password', $fedexPassword);
-$configWriter->save('carriers/fedex/production_webservices_url', $fedexEndpointUrl);
+$configWriter->save('carriers/fedex/active', '1');
+$configWriter->save('carriers/fedex/sandbox_mode', '1');
+$configWriter->save(\Magento\Sales\Model\Order\Shipment::XML_PATH_STORE_ZIP, '90210');
 
 $scopeConfig = $objectManager->get(ScopeConfigInterface::class);
 $scopeConfig->clean();

--- a/dev/tests/integration/testsuite/Magento/GraphQl/FedEx/_files/enable_fedex_shipping_method_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/FedEx/_files/enable_fedex_shipping_method_rollback.php
@@ -18,4 +18,5 @@ $configWriter->delete('carriers/fedex/account');
 $configWriter->delete('carriers/fedex/meter_number');
 $configWriter->delete('carriers/fedex/key');
 $configWriter->delete('carriers/fedex/password');
-$configWriter->delete('carriers/fedex/production_webservices_url');
+$configWriter->delete('carriers/fedex/sandbox_mode');
+$configWriter->delete(\Magento\Sales\Model\Order\Shipment::XML_PATH_STORE_ZIP);


### PR DESCRIPTION
### Description (*)
Creates a mock soap client for fetching rates during test execution.

### Fixed Issues (if relevant)
1. magento/graphql-ce#740

### Manual testing scenarios (*)
1. `cd dev/tests/api-functional`
2. `../../../vendor/bin/phpunit testsuite/Magento/GraphQl/FedEx/SetFedExShippingMethodsOnCartTest.php`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
