### PR TITLE
Remove PaymentMethodAdditionalDataInput From Schema

### DIFF
--- a/dev/tests/api-functional/_files/Magento/TestModuleAuthorizenetAcceptjs/registration.php
+++ b/dev/tests/api-functional/_files/Magento/TestModuleAuthorizenetAcceptjs/registration.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 use Magento\Framework\Component\ComponentRegistrar;
 

--- a/dev/tests/api-functional/_files/Magento/TestModuleFedex/registration.php
+++ b/dev/tests/api-functional/_files/Magento/TestModuleFedex/registration.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 use Magento\Framework\Component\ComponentRegistrar;
 
 $registrar = new ComponentRegistrar();

--- a/dev/tests/api-functional/_files/Magento/TestModuleUsps/registration.php
+++ b/dev/tests/api-functional/_files/Magento/TestModuleUsps/registration.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 use Magento\Framework\Component\ComponentRegistrar;
 
 $registrar = new ComponentRegistrar();


### PR DESCRIPTION
### Description (*)
The empty input `PaymentMethodAdditionalDataInput` generated an invalid schema. This commit updates the implementation for online payment methods and allows this element to be removed. Payment method specific inputs are moved out of `PaymentMethodAdditionalDataInput` and into `PaymentMethodInput` ie:

**Before**
```graphql
mutation {
  setPaymentMethodOnCart(input:{
    cart_id:"blahblahblah"
    payment_method:{
      code:"authorizenet_acceptjs"
      additional_data:{
        authorizenet_acceptjs:{
          opaque_data_descriptor: "COMMON.ACCEPT.INAPP.PAYMENT"
          opaque_data_value: "fake-nonce"
          cc_last_4: 1111
        }
      }
    }
  }) {
    cart {
      selected_payment_method {
        code
      }
    }
  }
}
```

**After**
```graphql
mutation {
  setPaymentMethodOnCart(input:{
    cart_id:"blahblahblah"
    payment_method:{
      code:"authorizenet_acceptjs"
      authorizenet_acceptjs:{
        opaque_data_descriptor: "COMMON.ACCEPT.INAPP.PAYMENT"
        opaque_data_value: "fake-nonce"
        cc_last_4: 1111
      }
    }
  }) {
    cart {
      selected_payment_method {
        code
      }
    }
  }
}
```

This PR also adds tests for the AuthorizenetAcceptjsGraphQl module and the test module for mocking the required response data.

### Fixed Issues (if relevant)
1. magento/graphql-ce#751

### Manual testing scenarios (*)
1. `cd dev/tests/api-functional`
2. `../../../vendor/bin/phpunit testsuite/Magento/GraphQl/AuthorizenetAcceptjs/Customer/SetPaymentMethodTest.php`
3.`../../../vendor/bin/phpunit testsuite/Magento/GraphQl/AuthorizenetAcceptjs/Guest/SetPaymentMethodTest.php`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
