### PR TITLE
#758: applied_taxes of empty cart causes 'Internal server error' message on PHP 7.2

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/CartPrices.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/CartPrices.php
@@ -73,7 +73,7 @@ class CartPrices implements ResolverInterface
         $appliedTaxesData = [];
         $appliedTaxes = $total->getAppliedTaxes();
 
-        if ($appliedTaxes === null || count($appliedTaxes) === 0) {
+        if (empty($appliedTaxes)) {
             return $appliedTaxesData;
         }
 

--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/CartPrices.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/CartPrices.php
@@ -73,7 +73,7 @@ class CartPrices implements ResolverInterface
         $appliedTaxesData = [];
         $appliedTaxes = $total->getAppliedTaxes();
 
-        if (count($appliedTaxes) === 0) {
+        if ($appliedTaxes === null || count($appliedTaxes) === 0) {
             return $appliedTaxesData;
         }
 

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CartTotalsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CartTotalsTest.php
@@ -64,32 +64,32 @@ class CartTotalsTest extends GraphQlAbstract
         self::assertEquals('USD', $appliedTaxesResponse[0]['amount']['currency']);
     }
 
-	/**
-	 * @magentoApiDataFixture Magento/Customer/_files/customer.php
-	 * @magentoApiDataFixture Magento/GraphQl/Tax/_files/tax_rule_for_region_1.php
-	 * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
-	 * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/apply_tax_for_simple_product.php
-	 * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
-	 * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_shipping_address.php
-	 * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_billing_address.php
-	 */
-	public function testGetCartTotalsWithEmptyCart()
-	{
-		$maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
-		$query = $this->getQuery($maskedQuoteId);
-		$response = $this->graphQlQuery($query, [], '', $this->getHeaderMap());
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/GraphQl/Tax/_files/tax_rule_for_region_1.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/apply_tax_for_simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_shipping_address.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_billing_address.php
+     */
+    public function testGetCartTotalsWithEmptyCart()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query, [], '', $this->getHeaderMap());
 
-		self::assertArrayHasKey('prices', $response['cart']);
-		$pricesResponse = $response['cart']['prices'];
-		self::assertEquals(0, $pricesResponse['grand_total']['value']);
-		self::assertEquals(0, $pricesResponse['subtotal_including_tax']['value']);
-		self::assertEquals(0, $pricesResponse['subtotal_excluding_tax']['value']);
-		self::assertEquals(0, $pricesResponse['subtotal_with_discount_excluding_tax']['value']);
+        self::assertArrayHasKey('prices', $response['cart']);
+        $pricesResponse = $response['cart']['prices'];
+        self::assertEquals(0, $pricesResponse['grand_total']['value']);
+        self::assertEquals(0, $pricesResponse['subtotal_including_tax']['value']);
+        self::assertEquals(0, $pricesResponse['subtotal_excluding_tax']['value']);
+        self::assertEquals(0, $pricesResponse['subtotal_with_discount_excluding_tax']['value']);
 
-		$appliedTaxesResponse = $pricesResponse['applied_taxes'];
+        $appliedTaxesResponse = $pricesResponse['applied_taxes'];
 
-		self::assertCount(0, $appliedTaxesResponse);
-	}
+        self::assertCount(0, $appliedTaxesResponse);
+    }
 
     /**
      * @magentoApiDataFixture Magento/Customer/_files/customer.php

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CartTotalsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CartTotalsTest.php
@@ -64,6 +64,33 @@ class CartTotalsTest extends GraphQlAbstract
         self::assertEquals('USD', $appliedTaxesResponse[0]['amount']['currency']);
     }
 
+	/**
+	 * @magentoApiDataFixture Magento/Customer/_files/customer.php
+	 * @magentoApiDataFixture Magento/GraphQl/Tax/_files/tax_rule_for_region_1.php
+	 * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+	 * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/apply_tax_for_simple_product.php
+	 * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+	 * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_shipping_address.php
+	 * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_billing_address.php
+	 */
+	public function testGetCartTotalsWithEmptyCart()
+	{
+		$maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+		$query = $this->getQuery($maskedQuoteId);
+		$response = $this->graphQlQuery($query, [], '', $this->getHeaderMap());
+
+		self::assertArrayHasKey('prices', $response['cart']);
+		$pricesResponse = $response['cart']['prices'];
+		self::assertEquals(0, $pricesResponse['grand_total']['value']);
+		self::assertEquals(0, $pricesResponse['subtotal_including_tax']['value']);
+		self::assertEquals(0, $pricesResponse['subtotal_excluding_tax']['value']);
+		self::assertEquals(0, $pricesResponse['subtotal_with_discount_excluding_tax']['value']);
+
+		$appliedTaxesResponse = $pricesResponse['applied_taxes'];
+
+		self::assertCount(0, $appliedTaxesResponse);
+	}
+
     /**
      * @magentoApiDataFixture Magento/Customer/_files/customer.php
      * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
@@ -59,31 +59,31 @@ class CartTotalsTest extends GraphQlAbstract
         self::assertEquals('USD', $appliedTaxesResponse[0]['amount']['currency']);
     }
 
-	/**
-	 * @magentoApiDataFixture Magento/GraphQl/Tax/_files/tax_rule_for_region_1.php
-	 * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
-	 * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/apply_tax_for_simple_product.php
-	 * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
-	 * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_shipping_address.php
-	 * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_billing_address.php
-	 */
-	public function testGetCartTotalsWithEmptyCart()
-	{
-		$maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
-		$query = $this->getQuery($maskedQuoteId);
-		$response = $this->graphQlQuery($query);
+    /**
+     * @magentoApiDataFixture Magento/GraphQl/Tax/_files/tax_rule_for_region_1.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/apply_tax_for_simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_shipping_address.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_billing_address.php
+     */
+    public function testGetCartTotalsWithEmptyCart()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query);
 
-		self::assertArrayHasKey('prices', $response['cart']);
-		$pricesResponse = $response['cart']['prices'];
-		self::assertEquals(0, $pricesResponse['grand_total']['value']);
-		self::assertEquals(0, $pricesResponse['subtotal_including_tax']['value']);
-		self::assertEquals(0, $pricesResponse['subtotal_excluding_tax']['value']);
-		self::assertEquals(0, $pricesResponse['subtotal_with_discount_excluding_tax']['value']);
+        self::assertArrayHasKey('prices', $response['cart']);
+        $pricesResponse = $response['cart']['prices'];
+        self::assertEquals(0, $pricesResponse['grand_total']['value']);
+        self::assertEquals(0, $pricesResponse['subtotal_including_tax']['value']);
+        self::assertEquals(0, $pricesResponse['subtotal_excluding_tax']['value']);
+        self::assertEquals(0, $pricesResponse['subtotal_with_discount_excluding_tax']['value']);
 
-		$appliedTaxesResponse = $pricesResponse['applied_taxes'];
+        $appliedTaxesResponse = $pricesResponse['applied_taxes'];
 
-		self::assertCount(0, $appliedTaxesResponse);
-	}
+        self::assertCount(0, $appliedTaxesResponse);
+    }
 
     /**
      * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
@@ -59,6 +59,32 @@ class CartTotalsTest extends GraphQlAbstract
         self::assertEquals('USD', $appliedTaxesResponse[0]['amount']['currency']);
     }
 
+	/**
+	 * @magentoApiDataFixture Magento/GraphQl/Tax/_files/tax_rule_for_region_1.php
+	 * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+	 * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/apply_tax_for_simple_product.php
+	 * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
+	 * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_shipping_address.php
+	 * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_billing_address.php
+	 */
+	public function testGetCartTotalsWithEmptyCart()
+	{
+		$maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+		$query = $this->getQuery($maskedQuoteId);
+		$response = $this->graphQlQuery($query);
+
+		self::assertArrayHasKey('prices', $response['cart']);
+		$pricesResponse = $response['cart']['prices'];
+		self::assertEquals(0, $pricesResponse['grand_total']['value']);
+		self::assertEquals(0, $pricesResponse['subtotal_including_tax']['value']);
+		self::assertEquals(0, $pricesResponse['subtotal_excluding_tax']['value']);
+		self::assertEquals(0, $pricesResponse['subtotal_with_discount_excluding_tax']['value']);
+
+		$appliedTaxesResponse = $pricesResponse['applied_taxes'];
+
+		self::assertCount(0, $appliedTaxesResponse);
+	}
+
     /**
      * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
From PHP 7.2 onward there is a warning generated when attempting to call `count()` on anything that is not an array or an object implementing Countable, when a cart is created, initially the appliedTaxes are null until a product is added.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/graphql-ce#758: Cart applied_taxes of empty cart causes 'Internal server error' message on PHP 7.2

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. See reproduction steps of magento/graphql-ce#758

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
