### PR TITLE
Added DateTypePool and dataTypes in array di.xml

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Product/Option/DateType.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Product/Option/DateType.php
@@ -17,6 +17,34 @@ use Magento\Framework\Stdlib\DateTime;
 class DateType extends ProductDateOptionType
 {
     /**
+     * @var array
+     */
+    protected $dateTypePool;
+
+    /**
+     * DateType constructor.
+     *
+     * @param \Magento\Checkout\Model\Session $checkoutSession
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate
+     * @param array $data
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @param \Magento\CatalogGraphQl\Model\Product\Option\DateTypePool $dateTypePool
+     */
+    public function __construct(
+        \Magento\Checkout\Model\Session $checkoutSession,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate,
+        array $data = [],
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null,
+        \Magento\CatalogGraphQl\Model\Product\Option\DateTypePool $dateTypePool
+    ) {
+        $this->dateTypePool = $dateTypePool;
+
+        parent::__construct($checkoutSession, $scopeConfig, $localeDate, $data, $serializer);
+    }
+
+    /**
      * Make valid string as a value of date option type for GraphQl queries
      *
      * @param array $values All product option values, i.e. array (option_id => mixed, option_id => mixed...)
@@ -42,7 +70,12 @@ class DateType extends ProductDateOptionType
     {
         if (isset($values[$this->getOption()->getId()])) {
             $value = $values[$this->getOption()->getId()];
-            $dateTime = \DateTime::createFromFormat(DateTime::DATETIME_PHP_FORMAT, $value);
+
+            $dateType = $this->getOption()->getType();
+            $dateTypePool = $this->dateTypePool->getDataTypes();
+
+            $dateTime = \DateTime::createFromFormat($dateTypePool[$dateType], $value);
+
             $values[$this->getOption()->getId()] = [
                 'date' => $value,
                 'year' => $dateTime->format('Y'),

--- a/app/code/Magento/CatalogGraphQl/Model/Product/Option/DateType.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Product/Option/DateType.php
@@ -10,6 +10,7 @@ namespace Magento\CatalogGraphQl\Model\Product\Option;
 use Magento\Catalog\Model\Product\Option\Type\Date as ProductDateOptionType;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Stdlib\DateTime;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 
 /**
  * @inheritdoc
@@ -75,6 +76,15 @@ class DateType extends ProductDateOptionType
             $dateTypePool = $this->dateTypePool->getDataTypes();
 
             $dateTime = \DateTime::createFromFormat($dateTypePool[$dateType], $value);
+
+            if (!$dateTime) {
+                throw new GraphQlInputException(
+                    __(
+                        'Invalid format provided. Please use \'%format\' for \'%type\' type instead of formatting.',
+                        ['format' => $dateTypePool[$dateType], 'type' => $dateType]
+                    )
+                );
+            }
 
             $values[$this->getOption()->getId()] = [
                 'date' => $value,

--- a/app/code/Magento/CatalogGraphQl/Model/Product/Option/DateTypePool.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Product/Option/DateTypePool.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types = 1);
+
+namespace Magento\CatalogGraphQl\Model\Product\Option;
+
+/**
+ * Class DateTypePool
+ *
+ * Pool of Date Types
+ */
+class DateTypePool
+{
+    /**
+     * @var array
+     */
+    protected $dataTypes;
+
+    /**
+     * @param array $dataTypes
+     */
+    public function __construct(array $dataTypes = [])
+    {
+        $this->dataTypes = $dataTypes;
+    }
+
+    /**
+     * Retrieve Date Types
+     *
+     * @return array
+     */
+    public function getDataTypes()
+    {
+        return $this->dataTypes;
+    }
+}

--- a/app/code/Magento/CatalogGraphQl/etc/di.xml
+++ b/app/code/Magento/CatalogGraphQl/etc/di.xml
@@ -37,6 +37,15 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\CatalogGraphQl\Model\Product\Option\DateTypePool">
+        <arguments>
+            <argument name="dataTypes" xsi:type="array">
+                <item name="date" xsi:type="string">Y-m-d</item>
+                <item name="date_time" xsi:type="string">Y-m-d H:i:s</item>
+                <item name="time" xsi:type="string">Y-m-d H:i:s</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CompositeCollectionProcessor">
         <arguments>
             <argument name="collectionProcessors" xsi:type="array">


### PR DESCRIPTION
### Description (*)

Added Magento\CatalogGraphQl\Model\Product\Option\DateTypePool class.
Added dataTypes array (Y-m-d, Y-m-d H:i:s, Y-m-d H:i:s) in di.xml.
Implemented DI for DateTypePool with the constructor.

### Fixed Issues

1. magento/graphql-ce#761: [Customizable Options] Call to a member function format() on boolean

### Manual testing scenarios (*)

1. Create Simple Product similar to :
SKU: simple-product-1
qty: 100500
Customizable options:
type: date

2. Perform query for Customer and use header
Header:

```
{
  "Authorization": "Bearer {{ CUSTOMER_TOKEN }}"
}
```

Query:

```
mutation {
  addSimpleProductsToCart(
    input: {
      cart_id: "{{ CART_ID }}"
      cart_items: {
        data: {
          quantity: 1
          sku: "simple-product-3"
        }
        customizable_options: [
          {
            id: 1
            value_string: "12-12-12"
          }
        ]
      }
    }
  ) {
    cart {
      items {
        quantity
        product {
          sku
        }
      }
    }
  }
}
```
3. Product was added to cart

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
