### PR TITLE
Declare @doc and @resolver directives

### DIFF
--- a/app/code/Magento/GraphQl/etc/schema.graphqls
+++ b/app/code/Magento/GraphQl/etc/schema.graphqls
@@ -36,6 +36,8 @@ directive @resolver(class: String="") on QUERY
     | ENUM_VALUE
     | INPUT_OBJECT
     | INPUT_FIELD_DEFINITION
+    
+directive @typeResolver(class: String="") on INTERFACE
 
 type Query {
 }

--- a/app/code/Magento/GraphQl/etc/schema.graphqls
+++ b/app/code/Magento/GraphQl/etc/schema.graphqls
@@ -37,7 +37,7 @@ directive @resolver(class: String="") on QUERY
     | INPUT_OBJECT
     | INPUT_FIELD_DEFINITION
     
-directive @typeResolver(class: String="") on INTERFACE
+directive @typeResolver(class: String="") on INTERFACE | OBJECT
 
 type Query {
 }

--- a/app/code/Magento/GraphQl/etc/schema.graphqls
+++ b/app/code/Magento/GraphQl/etc/schema.graphqls
@@ -1,6 +1,42 @@
 # Copyright © Magento, Inc. All rights reserved.
 # See COPYING.txt for license details.
 
+directive @doc(description: String="") on QUERY
+    | MUTATION
+    | FIELD
+    | FRAGMENT_DEFINITION
+    | FRAGMENT_SPREAD
+    | INLINE_FRAGMENT
+    | SCHEMA
+    | SCALAR
+    | OBJECT
+    | FIELD_DEFINITION
+    | ARGUMENT_DEFINITION
+    | INTERFACE
+    | UNION
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+
+directive @resolver(class: String="") on QUERY
+    | MUTATION
+    | FIELD
+    | FRAGMENT_DEFINITION
+    | FRAGMENT_SPREAD
+    | INLINE_FRAGMENT
+    | SCHEMA
+    | SCALAR
+    | OBJECT
+    | FIELD_DEFINITION
+    | ARGUMENT_DEFINITION
+    | INTERFACE
+    | UNION
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+
 type Query {
 }
 

--- a/app/code/Magento/GraphQl/etc/schema.graphqls
+++ b/app/code/Magento/GraphQl/etc/schema.graphqls
@@ -39,6 +39,8 @@ directive @resolver(class: String="") on QUERY
     
 directive @typeResolver(class: String="") on INTERFACE | OBJECT
 
+directive @cache(cacheIdentity: String="" cachable: Boolean=true) on QUERY
+
 type Query {
 }
 


### PR DESCRIPTION
### Description (*)

These declarations remove a lot of warnings from the PHPStorm GraphQl plugin while editing schema.graphqls files.

### References:

* https://graphql.github.io/graphql-spec/June2018/#sec-Type-System.Directives
* https://www.apollographql.com/docs/graphql-tools/schema-directives/

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
