### PR TITLE
graphQl-786: fixed the quantity field in the bundle item option

### DIFF
--- a/app/code/Magento/BundleGraphQl/Model/Resolver/Links/Collection.php
+++ b/app/code/Magento/BundleGraphQl/Model/Resolver/Links/Collection.php
@@ -117,6 +117,7 @@ class Collection
                 'price' => $link->getSelectionPriceValue(),
                 'position' => $link->getPosition(),
                 'id' => $link->getSelectionId(),
+                'qty' => (int)$link->getSelectionQty(),
                 'quantity' => (int)$link->getSelectionQty(),
                 'is_default' => (bool)$link->getIsDefault(),
                 'price_type' => $this->enumLookup->getEnumValueFromField(

--- a/app/code/Magento/BundleGraphQl/Model/Resolver/Links/Collection.php
+++ b/app/code/Magento/BundleGraphQl/Model/Resolver/Links/Collection.php
@@ -117,7 +117,7 @@ class Collection
                 'price' => $link->getSelectionPriceValue(),
                 'position' => $link->getPosition(),
                 'id' => $link->getSelectionId(),
-                'qty' => (int)$link->getSelectionQty(),
+                'quantity' => (int)$link->getSelectionQty(),
                 'is_default' => (bool)$link->getIsDefault(),
                 'price_type' => $this->enumLookup->getEnumValueFromField(
                     'PriceTypeEnum',

--- a/app/code/Magento/BundleGraphQl/Model/Resolver/Links/Collection.php
+++ b/app/code/Magento/BundleGraphQl/Model/Resolver/Links/Collection.php
@@ -117,8 +117,8 @@ class Collection
                 'price' => $link->getSelectionPriceValue(),
                 'position' => $link->getPosition(),
                 'id' => $link->getSelectionId(),
-                'qty' => (int)$link->getSelectionQty(),
-                'quantity' => (int)$link->getSelectionQty(),
+                'qty' => (float)$link->getSelectionQty(),
+                'quantity' => (float)$link->getSelectionQty(),
                 'is_default' => (bool)$link->getIsDefault(),
                 'price_type' => $this->enumLookup->getEnumValueFromField(
                     'PriceTypeEnum',

--- a/app/code/Magento/BundleGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/BundleGraphQl/etc/schema.graphqls
@@ -14,6 +14,7 @@ type BundleItem @doc(description: "BundleItem defines an individual item in a bu
 type BundleItemOption @doc(description: "BundleItemOption defines characteristics and options for a specific bundle item.") {
     id: Int @doc(description: "The ID assigned to the bundled item option.")
     label: String @doc(description: "The text that identifies the bundled item option.") @resolver(class: "Magento\\BundleGraphQl\\Model\\Resolver\\Options\\Label")
+    qty: Float @deprecated(reason: "The `qty` is deprecated. Use `quantity` instead.") @doc(description: "Indicates the quantity of this specific bundle item.")
     quantity: Float @doc(description: "Indicates the quantity of this specific bundle item.")
     position: Int @doc(description: "When a bundle item contains multiple options, the relative position of this option compared to the other options.")
     is_default: Boolean @doc(description: "Indicates whether this option is the default option.")

--- a/app/code/Magento/BundleGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/BundleGraphQl/etc/schema.graphqls
@@ -14,7 +14,7 @@ type BundleItem @doc(description: "BundleItem defines an individual item in a bu
 type BundleItemOption @doc(description: "BundleItemOption defines characteristics and options for a specific bundle item.") {
     id: Int @doc(description: "The ID assigned to the bundled item option.")
     label: String @doc(description: "The text that identifies the bundled item option.") @resolver(class: "Magento\\BundleGraphQl\\Model\\Resolver\\Options\\Label")
-    qty: Float @doc(description: "Indicates the quantity of this specific bundle item.")
+    quantity: Float @doc(description: "Indicates the quantity of this specific bundle item.")
     position: Int @doc(description: "When a bundle item contains multiple options, the relative position of this option compared to the other options.")
     is_default: Boolean @doc(description: "Indicates whether this option is the default option.")
     price: Float @doc(description: "The price of the selected option.")

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Bundle/BundleProductViewTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Bundle/BundleProductViewTest.php
@@ -58,7 +58,7 @@ class BundleProductViewTest extends GraphQlAbstract
               sku              
               options {
                 id
-                qty
+                quantity
                 position
                 is_default
                 price
@@ -143,7 +143,7 @@ QUERY;
               sku              
               options {
                 id
-                qty
+                quantity
                 position
                 is_default
                 price
@@ -269,7 +269,7 @@ QUERY;
             $actualResponse['items'][0]['options'][0],
             [
                 'id' => $bundleProductLink->getId(),
-                'qty' => (int)$bundleProductLink->getQty(),
+                'quantity' => (int)$bundleProductLink->getQty(),
                 'position' => $bundleProductLink->getPosition(),
                 'is_default' => (bool)$bundleProductLink->getIsDefault(),
                  'price_type' => self::KEY_PRICE_TYPE_FIXED,

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Bundle/BundleProductViewTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Bundle/BundleProductViewTest.php
@@ -428,8 +428,9 @@ QUERY;
 QUERY;
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('GraphQL response contains errors: Cannot'. ' ' .
-            'query field "qty" on type "ProductInterface".');
+        $this->expectExceptionMessage(
+            'GraphQL response contains errors: Cannot query field "qty" on type "ProductInterface".'
+        );
         $this->graphQlQuery($query);
     }
 }


### PR DESCRIPTION
### Description (*)
Changed the name of quantity field of the Bundle Item Option (`qty` renamed to `quantity`).

### Fixed Issues (if relevant)
1. #786: BundleItemOption.qty / quantity schema inconsistency

