### PR TITLE
graphQl-738: un-skipped and fixed the media gallery test on the product

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/MediaGalleryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/MediaGalleryTest.php
@@ -87,7 +87,6 @@ QUERY;
      */
     public function testProductMediaGalleryEntries()
     {
-        $this->markTestSkipped('https://github.com/magento/graphql-ce/issues/738');
         $productSku = 'simple';
         $query = <<<QUERY
 {
@@ -107,7 +106,7 @@ QUERY;
         $response = $this->graphQlQuery($query);
 
         self::assertArrayHasKey('file', $response['products']['items'][0]['media_gallery_entries'][0]);
-        self::assertContains('magento_image.jpg', $response['products']['items'][0]['media_gallery_entries'][0]['url']);
+        self::assertContains('magento_image.jpg', $response['products']['items'][0]['media_gallery_entries'][0]['file']);
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/MediaGalleryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/MediaGalleryTest.php
@@ -106,7 +106,10 @@ QUERY;
         $response = $this->graphQlQuery($query);
 
         self::assertArrayHasKey('file', $response['products']['items'][0]['media_gallery_entries'][0]);
-        self::assertContains('magento_image.jpg', $response['products']['items'][0]['media_gallery_entries'][0]['file']);
+        self::assertContains(
+            'magento_image.jpg',
+            $response['products']['items'][0]['media_gallery_entries'][0]['file']
+        );
     }
 
     /**


### PR DESCRIPTION
### Description (*)
Un-skipped and fixed \Magento\GraphQl\Catalog\MediaGalleryTest::testProductMediaGalleryEntries test.

### Fixed Issues (if relevant)
1. #738: Unskip test for magento/graphql-ce#61

