### PR TITLE
[Checkout] Prevent generating new masked quote id for same quote

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Cart/CreateEmptyCartForCustomer.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/CreateEmptyCartForCustomer.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace Magento\QuoteGraphQl\Model\Cart;
 
-use Magento\Framework\App\ObjectManager;
 use Magento\Quote\Api\CartManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
@@ -49,13 +48,12 @@ class CreateEmptyCartForCustomer
         CartManagementInterface $cartManagement,
         QuoteIdMaskFactory $quoteIdMaskFactory,
         QuoteIdMaskResourceModel $quoteIdMaskResourceModel,
-        QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId = null
+        QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId
     ) {
         $this->cartManagement = $cartManagement;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->quoteIdMaskResourceModel = $quoteIdMaskResourceModel;
-        $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId ?? ObjectManager::getInstance()
-                ->get(QuoteIdToMaskedQuoteIdInterface::class);
+        $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId;
     }
 
     /**

--- a/app/code/Magento/QuoteGraphQl/Model/Cart/CreateEmptyCartForCustomer.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/CreateEmptyCartForCustomer.php
@@ -7,8 +7,11 @@ declare(strict_types=1);
 
 namespace Magento\QuoteGraphQl\Model\Cart;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Quote\Api\CartManagementInterface;
+use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
 use Magento\Quote\Model\ResourceModel\Quote\QuoteIdMask as QuoteIdMaskResourceModel;
 
 /**
@@ -32,18 +35,27 @@ class CreateEmptyCartForCustomer
     private $quoteIdMaskResourceModel;
 
     /**
+     * @var QuoteIdToMaskedQuoteIdInterface
+     */
+    private $quoteIdToMaskedQuoteId;
+
+    /**
      * @param CartManagementInterface $cartManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
      * @param QuoteIdMaskResourceModel $quoteIdMaskResourceModel
+     * @param QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId
      */
     public function __construct(
         CartManagementInterface $cartManagement,
         QuoteIdMaskFactory $quoteIdMaskFactory,
-        QuoteIdMaskResourceModel $quoteIdMaskResourceModel
+        QuoteIdMaskResourceModel $quoteIdMaskResourceModel,
+        QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId = null
     ) {
         $this->cartManagement = $cartManagement;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->quoteIdMaskResourceModel = $quoteIdMaskResourceModel;
+        $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId ?? ObjectManager::getInstance()
+                ->get(QuoteIdToMaskedQuoteIdInterface::class);
     }
 
     /**
@@ -55,16 +67,56 @@ class CreateEmptyCartForCustomer
      */
     public function execute(int $customerId, string $predefinedMaskedQuoteId = null): string
     {
-        $quoteId = $this->cartManagement->createEmptyCartForCustomer($customerId);
+        $quoteId = (int) $this->cartManagement->createEmptyCartForCustomer($customerId);
 
-        $quoteIdMask = $this->quoteIdMaskFactory->create();
-        $quoteIdMask->setQuoteId($quoteId);
-
-        if (isset($predefinedMaskedQuoteId)) {
-            $quoteIdMask->setMaskedId($predefinedMaskedQuoteId);
+        if ($predefinedMaskedQuoteId !== null) {
+            $maskedId = $this->createPredefinedMaskId($quoteId, $predefinedMaskedQuoteId);
+        } else {
+            $maskedId = $this->getQuoteMaskId($quoteId);
         }
 
+        return $maskedId;
+    }
+
+    /**
+     * Create quote masked id from predefined value
+     *
+     * @param int $quoteId
+     * @param string $maskId
+     * @return string
+     * @throws \Magento\Framework\Exception\AlreadyExistsException
+     */
+    private function createPredefinedMaskId(int $quoteId, string $maskId): string
+    {
+        /** @var QuoteIdMask $quoteIdMask */
+        $quoteIdMask = $this->quoteIdMaskFactory->create();
+        $quoteIdMask->setQuoteId($quoteId);
+        $quoteIdMask->setMaskedId($maskId);
+
         $this->quoteIdMaskResourceModel->save($quoteIdMask);
+
         return $quoteIdMask->getMaskedId();
+    }
+
+    /**
+     * Fetch or create masked id for customer's active quote
+     *
+     * @param int $quoteId
+     * @return string
+     * @throws \Magento\Framework\Exception\AlreadyExistsException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    private function getQuoteMaskId(int $quoteId): string
+    {
+        $maskedId = $this->quoteIdToMaskedQuoteId->execute($quoteId);
+        if ($maskedId === '') {
+            $quoteIdMask = $this->quoteIdMaskFactory->create();
+            $quoteIdMask->setQuoteId($quoteId);
+
+            $this->quoteIdMaskResourceModel->save($quoteIdMask);
+            $maskedId = $quoteIdMask->getMaskedId();
+        }
+
+        return $maskedId;
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CreateEmptyCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CreateEmptyCartTest.php
@@ -74,6 +74,25 @@ class CreateEmptyCartTest extends GraphQlAbstract
     }
 
     /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     */
+    public function testCreateEmptyMultipleRequestsCart()
+    {
+        $query = $this->getQuery();
+        $response = $this->graphQlMutation($query, [], '', $this->getHeaderMapWithCustomerToken());
+
+        self::assertArrayHasKey('createEmptyCart', $response);
+        self::assertNotEmpty($response['createEmptyCart']);
+        $maskedCartId = $response['createEmptyCart'];
+
+        $response = $this->graphQlMutation($query, [], '', $this->getHeaderMapWithCustomerToken());
+        self::assertArrayHasKey('createEmptyCart', $response);
+        self::assertNotEmpty($response['createEmptyCart']);
+
+        self::assertEquals($maskedCartId, $response['createEmptyCart']);
+    }
+
+    /**
      * @magentoApiDataFixture Magento/Store/_files/second_store.php
      * @magentoApiDataFixture Magento/Customer/_files/customer.php
      */


### PR DESCRIPTION
### Description (*)
This commit prevents the `createEmptyCart` mutation from generating a new masked quote id for the same customer quote.

### Fixed Issues
1. magento/graphql-ce#773

### Manual testing scenarios (*)
Follow the steps to reproduce outlined in #773 
The result of `createEmptyCart` should be unique per quote and not per request.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
