### PR TITLE
Mark config fixtures as deprecated

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/AuthorizenetAcceptjs/Customer/SetPaymentMethodTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/AuthorizenetAcceptjs/Customer/SetPaymentMethodTest.php
@@ -64,13 +64,15 @@ class SetPaymentMethodTest extends GraphQlAbstract
     /**
      * @magentoApiDataFixture Magento/Customer/_files/customer.php
      * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/enable_offline_shipping_methods.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_shipping_address.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_billing_address.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_flatrate_shipping_method.php
      * @magentoApiDataFixture Magento/GraphQl/AuthorizenetAcceptjs/_files/enable_authorizenetacceptjs.php
+     * @magentoConfigFixture default_store carriers/flatrate/active 1
+     * @magentoConfigFixture default_store carriers/tablerate/active 1
+     * @magentoConfigFixture default_store carriers/freeshipping/active 1
      * @param string $nonce
      * @param string $descriptor
      * @param bool $expectSuccess

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/AuthorizenetAcceptjs/Guest/SetPaymentMethodTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/AuthorizenetAcceptjs/Guest/SetPaymentMethodTest.php
@@ -63,7 +63,6 @@ class SetPaymentMethodTest extends GraphQlAbstract
 
     /**
      * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
-     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/enable_offline_shipping_methods.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/set_guest_email.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
@@ -71,6 +70,9 @@ class SetPaymentMethodTest extends GraphQlAbstract
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_billing_address.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_flatrate_shipping_method.php
      * @magentoApiDataFixture Magento/GraphQl/AuthorizenetAcceptjs/_files/enable_authorizenetacceptjs.php
+     * @magentoConfigFixture default_store carriers/flatrate/active 1
+     * @magentoConfigFixture default_store carriers/tablerate/active 1
+     * @magentoConfigFixture default_store carriers/freeshipping/active 1
      * @param string $nonce
      * @param string $descriptor
      * @param bool $expectSuccess

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_all_active_payment_methods.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_all_active_payment_methods.php
@@ -4,7 +4,13 @@
  * See COPYING.txt for license details.
  */
 /**
- * @deprecated
+ * @deprecated use next @magentoConfigFixture instead:
+ * @magentoConfigFixture default_store payment/fake_vault/active 0
+ * @magentoConfigFixture default_store payment/paypal_billing_agreement/active 0
+ * @magentoConfigFixture default_store payment/fake/active 0
+ * @magentoConfigFixture default_store payment/checkmo/active 0
+ * @magentoConfigFixture default_store payment/free/active 0
+ *
  */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_all_active_payment_methods.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_all_active_payment_methods.php
@@ -3,6 +3,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+/**
+ * @deprecated
+ */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_all_active_payment_methods.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_all_active_payment_methods.php
@@ -12,7 +12,6 @@
  * @magentoConfigFixture default_store payment/free/active 0
  *
  */
-// TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 
 use Magento\Config\Model\Config;

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_all_active_payment_methods_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_all_active_payment_methods_rollback.php
@@ -6,7 +6,6 @@
 /**
  * @deprecated use @magentoConfigFixture instead.
  */
-// TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 
 use Magento\Framework\App\Config\ScopeConfigInterface;

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_all_active_payment_methods_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_all_active_payment_methods_rollback.php
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 /**
- * @deprecated
+ * @deprecated use @magentoConfigFixture instead.
  */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_all_active_payment_methods_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_all_active_payment_methods_rollback.php
@@ -3,6 +3,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+/**
+ * @deprecated
+ */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_guest_checkout.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_guest_checkout.php
@@ -4,7 +4,8 @@
  * See COPYING.txt for license details.
  */
 /**
- * @deprecated
+ * @deprecated use next @magentoConfigFixture instead:
+ * @magentoConfigFixture default_store checkout/options/guest_checkout 0
  */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_guest_checkout.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_guest_checkout.php
@@ -7,7 +7,6 @@
  * @deprecated use next @magentoConfigFixture instead:
  * @magentoConfigFixture default_store checkout/options/guest_checkout 0
  */
-// TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 
 use Magento\Framework\App\Config\Storage\Writer;

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_guest_checkout.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_guest_checkout.php
@@ -3,6 +3,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+/**
+ * @deprecated
+ */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_guest_checkout_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_guest_checkout_rollback.php
@@ -6,7 +6,6 @@
 /**
  * @deprecated use @magentoConfigFixture instead.
  */
-// TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 
 use Magento\Framework\App\Config\Storage\Writer;

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_guest_checkout_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_guest_checkout_rollback.php
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 /**
- * @deprecated
+ * @deprecated use @magentoConfigFixture instead.
  */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_guest_checkout_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_guest_checkout_rollback.php
@@ -3,6 +3,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+/**
+ * @deprecated
+ */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_offline_shipping_methods.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_offline_shipping_methods.php
@@ -9,7 +9,6 @@
  * @magentoConfigFixture default_store carriers/tablerate/active 0
  * @magentoConfigFixture default_store carriers/freeshipping/active 0
  */
-// TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 
 use Magento\Framework\App\Config\Storage\Writer;

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_offline_shipping_methods.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_offline_shipping_methods.php
@@ -3,6 +3,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+/**
+ * @deprecated
+ */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_offline_shipping_methods.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_offline_shipping_methods.php
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 /**
- * @deprecated
+ * @deprecated use next @magentoConfigFixture instead:
+ * @magentoConfigFixture default_store carriers/flatrate/active 0
+ * @magentoConfigFixture default_store carriers/tablerate/active 0
+ * @magentoConfigFixture default_store carriers/freeshipping/active 0
  */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_offline_shipping_methods_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_offline_shipping_methods_rollback.php
@@ -6,7 +6,6 @@
 /**
  * @deprecated use next @magentoConfigFixture instead.
  */
-// TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 
 use Magento\Framework\App\Config\Storage\Writer;

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_offline_shipping_methods_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_offline_shipping_methods_rollback.php
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 /**
- * @deprecated
+ * @deprecated use next @magentoConfigFixture instead.
  */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_offline_shipping_methods_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/disable_offline_shipping_methods_rollback.php
@@ -3,6 +3,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+/**
+ * @deprecated
+ */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_payment_methods.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_payment_methods.php
@@ -11,7 +11,6 @@
  * @magentoConfigFixture default_store payment/purchaseorder/active 1
  * @magentoConfigFixture default_store payment/authorizenet_acceptjs/active 1
  */
-// TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 
 use Magento\Framework\App\Config\Storage\Writer;

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_payment_methods.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_payment_methods.php
@@ -4,7 +4,12 @@
  * See COPYING.txt for license details.
  */
 /**
- * @deprecated
+ * @deprecated use next @magentoConfigFixture instead:
+ * @magentoConfigFixture default_store payment/banktransfer/active 1
+ * @magentoConfigFixture default_store payment/cashondelivery/active 1
+ * @magentoConfigFixture default_store payment/checkmo/active 1
+ * @magentoConfigFixture default_store payment/purchaseorder/active 1
+ * @magentoConfigFixture default_store payment/authorizenet_acceptjs/active 1
  */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_payment_methods.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_payment_methods.php
@@ -3,6 +3,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+/**
+ * @deprecated
+ */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_payment_methods_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_payment_methods_rollback.php
@@ -6,7 +6,6 @@
 /**
  * @deprecated use @magentoConfigFixture instead.
  */
-// TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 
 use Magento\Framework\App\Config\Storage\Writer;

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_payment_methods_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_payment_methods_rollback.php
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 /**
- * @deprecated
+ * @deprecated use @magentoConfigFixture instead.
  */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_payment_methods_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_payment_methods_rollback.php
@@ -3,6 +3,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+/**
+ * @deprecated
+ */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_shipping_methods.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_shipping_methods.php
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 /**
- * @deprecated
+ * @deprecated use next @magentoConfigFixture instead:
+ * @magentoConfigFixture default_store carriers/flatrate/active 1
+ * @magentoConfigFixture default_store carriers/tablerate/active 1
+ * @magentoConfigFixture default_store carriers/freeshipping/active 1
  */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_shipping_methods.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_shipping_methods.php
@@ -9,7 +9,6 @@
  * @magentoConfigFixture default_store carriers/tablerate/active 1
  * @magentoConfigFixture default_store carriers/freeshipping/active 1
  */
-// TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 
 use Magento\Framework\App\Config\Storage\Writer;

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_shipping_methods.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_shipping_methods.php
@@ -3,6 +3,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+/**
+ * @deprecated
+ */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_shipping_methods_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_shipping_methods_rollback.php
@@ -6,7 +6,6 @@
 /**
  * @deprecated use @magentoConfigFixture instead.
  */
-// TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 
 use Magento\Framework\App\Config\Storage\Writer;

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_shipping_methods_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_shipping_methods_rollback.php
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 /**
- * @deprecated
+ * @deprecated use @magentoConfigFixture instead.
  */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_shipping_methods_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Quote/_files/enable_offline_shipping_methods_rollback.php
@@ -3,6 +3,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+/**
+ * @deprecated
+ */
 // TODO: Should be removed in scope of https://github.com/magento/graphql-ce/issues/167
 declare(strict_types=1);
 


### PR DESCRIPTION

### Description (*)
Original issue https://github.com/magento/graphql-ce/issues/794
 - Fixtures with reference #167 to are marked as deprecated.
 - Checked tests.
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
