### PR TITLE
Query.country doesn't work

### DIFF
--- a/app/code/Magento/DirectoryGraphQl/Model/Resolver/Country.php
+++ b/app/code/Magento/DirectoryGraphQl/Model/Resolver/Country.php
@@ -15,6 +15,7 @@ use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\Reflection\DataObjectProcessor;
 use Magento\Directory\Api\CountryInformationAcquirerInterface;
 use Magento\Directory\Api\Data\CountryInformationInterface;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 
 /**
  * Country field resolver, used for GraphQL request processing.
@@ -53,6 +54,10 @@ class Country implements ResolverInterface
         array $value = null,
         array $args = null
     ) {
+        if (!isset($args['id'])) {
+            throw new GraphQlInputException(__('"Country id" should be specified.'));
+        }
+
         try {
             $country = $this->countryInformationAcquirer->getCountryInfo($args['id']);
         } catch (NoSuchEntityException $exception) {

--- a/app/code/Magento/DirectoryGraphQl/Model/Resolver/Country.php
+++ b/app/code/Magento/DirectoryGraphQl/Model/Resolver/Country.php
@@ -54,7 +54,7 @@ class Country implements ResolverInterface
         array $value = null,
         array $args = null
     ) {
-        if (!isset($args['id'])) {
+        if (empty($args['id'])) {
             throw new GraphQlInputException(__('"Country id" should be specified.'));
         }
 

--- a/app/code/Magento/DirectoryGraphQl/Model/Resolver/Country.php
+++ b/app/code/Magento/DirectoryGraphQl/Model/Resolver/Country.php
@@ -55,7 +55,7 @@ class Country implements ResolverInterface
         array $args = null
     ) {
         if (empty($args['id'])) {
-            throw new GraphQlInputException(__('"Country id" should be specified.'));
+            throw new GraphQlInputException(__('Country "id" value should be specified'));
         }
 
         try {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Directory/CountryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Directory/CountryTest.php
@@ -71,4 +71,25 @@ QUERY;
 
         $this->graphQlQuery($query);
     }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage GraphQL response contains errors: "Country id" should be specified.
+     */
+    public function testMissedInputParameterException()
+    {
+        $query = <<<QUERY
+{
+  country {
+    available_regions {
+      code
+      id
+      name
+    }
+  }
+}
+QUERY;
+
+        $this->graphQlQuery($query);
+    }
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Directory/CountryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Directory/CountryTest.php
@@ -74,7 +74,7 @@ QUERY;
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage GraphQL response contains errors: "Country id" should be specified.
+     * @expectedExceptionMessage Country "id" value should be specified
      */
     public function testMissedInputParameterException()
     {


### PR DESCRIPTION
### Description (*)
Original issue https://github.com/magento/graphql-ce/issues/798

### Manual testing scenarios (*)
Use the following request body to get country information
```{
  country {
    available_regions {
      code
      id
      name
    }
  }
}```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
