### PR TITLE
#813: [Test coverage] Update item qty for configurable product

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/UpdateConfigurableCartItemsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/UpdateConfigurableCartItemsTest.php
@@ -49,7 +49,8 @@ class UpdateConfigurableCartItemsTest extends GraphQlAbstract
     public function testUpdateConfigurableCartItemQuantity()
     {
         $reservedOrderId = 'test_cart_with_configurable';
-        $maskedQuoteId = $this->getMaskedQuoteId($reservedOrderId);
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute($reservedOrderId);
+
         $productSku = 'simple_10';
         $newQuantity = 123;
         $quoteItem = $this->getQuoteItemBySku($productSku, $reservedOrderId);
@@ -124,21 +125,5 @@ QUERY;
         }
 
         return $item;
-    }
-
-    /**
-     * @param $reservedOrderId
-     * @return string
-     * @throws NoSuchEntityException
-     */
-    private function getMaskedQuoteId(string $reservedOrderId): string
-    {
-        $quote = $this->quoteFactory->create();
-        $this->quoteResource->load($quote, $reservedOrderId, 'reserved_order_id');
-        $quoteIdMask = $this->quoteIdMaskFactory->create();
-        $quoteIdMask->setQuoteId($quote->getId())
-            ->save();
-
-        return $this->getMaskedQuoteIdByReservedOrderId->execute($reservedOrderId);
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/UpdateConfigurableCartItemsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/UpdateConfigurableCartItemsTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\GraphQl\ConfigurableProduct;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Framework\Exception\NoSuchEntityException as NoSuchEntityException;
+use Magento\GraphQl\Quote\GetMaskedQuoteIdByReservedOrderId;
+use Magento\Quote\Model\Quote\Item;
+use Magento\Quote\Model\QuoteFactory;
+use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\ResourceModel\Quote as QuoteResource;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+/**
+ * checks that qty of configurable product is updated in cart
+ */
+class UpdateConfigurableCartItemsTest extends GraphQlAbstract
+{
+    /**
+     * @var QuoteIdMaskFactory
+     */
+    protected $quoteIdMaskFactory;
+
+    /**
+     * @var GetMaskedQuoteIdByReservedOrderId
+     */
+    private $getMaskedQuoteIdByReservedOrderId;
+
+    /**
+     * @var ProductRepositoryInterface
+     */
+    private $productRepository;
+
+    /**
+     * @var QuoteFactory
+     */
+    private $quoteFactory;
+
+    /**
+     * @var QuoteResource
+     */
+    private $quoteResource;
+
+    /**
+     * @magentoApiDataFixture Magento/ConfigurableProduct/_files/quote_with_configurable_product.php
+     */
+    public function testUpdateConfigurableCartItemQuantity()
+    {
+        $reservedOrderId = 'test_cart_with_configurable';
+        $maskedQuoteId = $this->getMaskedQuoteId($reservedOrderId);
+        $productSku = 'simple_10';
+        $newQuantity = 123;
+        $quoteItem = $this->getQuoteItemBySku($productSku, $reservedOrderId);
+
+        $query = $this->getQuery($maskedQuoteId, (int)$quoteItem->getId(), $newQuantity);
+        $response = $this->graphQlMutation($query);
+
+        self::assertArrayHasKey('updateCartItems', $response);
+        self::assertArrayHasKey('quantity', $response['updateCartItems']['cart']['items']['0']);
+        self::assertEquals($newQuantity, $response['updateCartItems']['cart']['items']['0']['quantity']);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->getMaskedQuoteIdByReservedOrderId = $objectManager->get(GetMaskedQuoteIdByReservedOrderId::class);
+        $this->quoteFactory = $objectManager->get(QuoteFactory::class);
+        $this->quoteResource = $objectManager->get(QuoteResource::class);
+        $this->productRepository = $objectManager->get(ProductRepositoryInterface::class);
+        $this->quoteIdMaskFactory = Bootstrap::getObjectManager()->get(QuoteIdMaskFactory::class);
+    }
+
+    /**
+     * @param string $maskedQuoteId
+     * @param int $quoteItemId
+     * @param int $newQuantity
+     * @return string
+     */
+    private function getQuery(string $maskedQuoteId, int $quoteItemId, int $newQuantity): string
+    {
+        return <<<QUERY
+mutation {
+  updateCartItems(input: {
+    cart_id:"$maskedQuoteId"
+    cart_items: [
+      {
+        cart_item_id: $quoteItemId
+        quantity: $newQuantity
+      }
+    ]
+  }) {
+    cart {
+      items {
+        quantity
+      }
+    }
+  }
+}
+QUERY;
+    }
+
+    /**
+     * Returns quote item by product SKU
+     *
+     * @param string $sku
+     * @return Item|bool
+     * @throws NoSuchEntityException
+     */
+    private function getQuoteItemBySku(string $sku, string $reservedOrderId)
+    {
+        $quote = $this->quoteFactory->create();
+        $this->quoteResource->load($quote, $reservedOrderId, 'reserved_order_id');
+        $item = false;
+        foreach ($quote->getAllItems() as $quoteItem) {
+            if ($quoteItem->getSku() == $sku && $quoteItem->getProductType() == Configurable::TYPE_CODE &&
+                !$quoteItem->getParentItemId()) {
+                $item = $quoteItem;
+                break;
+            }
+        }
+
+        return $item;
+    }
+
+    /**
+     * @param $reservedOrderId
+     * @return string
+     * @throws NoSuchEntityException
+     */
+    private function getMaskedQuoteId(string $reservedOrderId): string
+    {
+        $quote = $this->quoteFactory->create();
+        $this->quoteResource->load($quote, $reservedOrderId, 'reserved_order_id');
+        $quoteIdMask = $this->quoteIdMaskFactory->create();
+        $quoteIdMask->setQuoteId($quote->getId())
+            ->save();
+
+        return $this->getMaskedQuoteIdByReservedOrderId->execute($reservedOrderId);
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/UpdateConfigurableCartItemsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/UpdateConfigurableCartItemsTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Magento\GraphQl\ConfigurableProduct;
 
-use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Framework\Exception\NoSuchEntityException as NoSuchEntityException;
 use Magento\GraphQl\Quote\GetMaskedQuoteIdByReservedOrderId;
@@ -33,11 +32,6 @@ class UpdateConfigurableCartItemsTest extends GraphQlAbstract
      * @var GetMaskedQuoteIdByReservedOrderId
      */
     private $getMaskedQuoteIdByReservedOrderId;
-
-    /**
-     * @var ProductRepositoryInterface
-     */
-    private $productRepository;
 
     /**
      * @var QuoteFactory
@@ -77,7 +71,6 @@ class UpdateConfigurableCartItemsTest extends GraphQlAbstract
         $this->getMaskedQuoteIdByReservedOrderId = $objectManager->get(GetMaskedQuoteIdByReservedOrderId::class);
         $this->quoteFactory = $objectManager->get(QuoteFactory::class);
         $this->quoteResource = $objectManager->get(QuoteResource::class);
-        $this->productRepository = $objectManager->get(ProductRepositoryInterface::class);
         $this->quoteIdMaskFactory = Bootstrap::getObjectManager()->get(QuoteIdMaskFactory::class);
     }
 

--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/_files/quote_with_configurable_product.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/_files/quote_with_configurable_product.php
@@ -40,3 +40,11 @@ $cart->save();
 /** @var $objectManager \Magento\TestFramework\ObjectManager */
 $objectManager = Bootstrap::getObjectManager();
 $objectManager->removeSharedInstance(\Magento\Checkout\Model\Session::class);
+
+/** @var \Magento\Quote\Model\QuoteIdMask $quoteIdMask */
+$quoteIdMask = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+    ->create(\Magento\Quote\Model\QuoteIdMaskFactory::class)
+    ->create();
+$quoteIdMask->setQuoteId($cart->getQuote()->getId());
+$quoteIdMask->setDataChanges(true);
+$quoteIdMask->save();


### PR DESCRIPTION
### Description (*)
This PR adds test coverage for updating item qty of configurable product

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/graphql-ce#813: [Test coverage] Update item qty for configurable product 
