### PR TITLE
Respect store header when loading customer object

### DIFF
--- a/app/code/Magento/CustomerGraphQl/Model/Customer/ScopeValidate.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/ScopeValidate.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CustomerGraphQl\Model\Customer;
+
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Customer\Model\Config\Share;
+use Magento\Framework\Exception\AuthenticationException;
+use Magento\GraphQl\Model\Query\ContextInterface;
+
+/**
+ * Validate customer is allowed in current store scope
+ */
+class ScopeValidate
+{
+    /**
+     * @var Share
+     */
+    private $shareConfig;
+
+    /**
+     * @param Share $shareConfig
+     */
+    public function __construct(
+        Share $shareConfig
+    ) {
+        $this->shareConfig = $shareConfig;
+    }
+
+    /**
+     * Validate customer is allowed in current store scope
+     *
+     * @param CustomerInterface $customer
+     * @param ContextInterface $context
+     * @throws AuthenticationException
+     */
+    public function execute(CustomerInterface $customer, ContextInterface $context): void
+    {
+        if ($this->shareConfig->isGlobalScope()) {
+            return;
+        }
+
+        $websiteId = $context->getExtensionAttributes()->getStore()->getWebsiteId();
+        if ($customer->getWebsiteId() !== $websiteId) {
+            throw new AuthenticationException(
+                __(
+                    'Customer with "%customerId" is not authorized in websiteId "%websiteId"',
+                    [
+                        'customerId' => $customer->getId(),
+                        'websiteId' => $websiteId
+                    ]
+                )
+            );
+        }
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GetCustomerTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GetCustomerTest.php
@@ -82,6 +82,73 @@ QUERY;
     }
 
     /**
+     * @magentoApiDataFixture Magento/Store/_files/second_website_with_two_stores.php
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoConfigFixture default/customer/account_share/scope 1
+     * @expectedException \Exception
+     * @expectedExceptionMessage The current customer isn't authorized.
+     */
+    public function testGetCustomerIfUserIsNotAuthorizedInCorrectScope()
+    {
+        $currentEmail = 'customer@example.com';
+        $currentPassword = 'password';
+
+        $query = <<<QUERY
+query {
+    customer {
+        firstname
+        lastname
+        email
+    }
+}
+QUERY;
+        $this->graphQlQuery(
+            $query,
+            [],
+            '',
+            array_merge(
+                ['Store' => 'fixture_second_store'],
+                $this->getCustomerAuthHeaders($currentEmail, $currentPassword)
+            )
+        );
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Store/_files/second_website_with_two_stores.php
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoConfigFixture default/customer/account_share/scope 0
+     */
+    public function testGetCustomerGlobalScopeConfiguration()
+    {
+        $currentEmail = 'customer@example.com';
+        $currentPassword = 'password';
+
+        $query = <<<QUERY
+query {
+    customer {
+        firstname
+        lastname
+        email
+    }
+}
+QUERY;
+
+        $response = $this->graphQlQuery(
+            $query,
+            [],
+            '',
+            array_merge(
+                ['Store' => 'fixture_second_store'],
+                $this->getCustomerAuthHeaders($currentEmail, $currentPassword)
+            )
+        );
+
+        $this->assertEquals('John', $response['customer']['firstname']);
+        $this->assertEquals('Smith', $response['customer']['lastname']);
+        $this->assertEquals($currentEmail, $response['customer']['email']);
+    }
+
+    /**
      * @magentoApiDataFixture Magento/Customer/_files/customer.php
      * @expectedException \Exception
      * @expectedExceptionMessage The account is locked.


### PR DESCRIPTION
### Description (*)
Only allows loading customer from website scope associated with customer.
Returns authorization exceptions when loading customer from different website
when account sharing is not global.

### Fixed Issues (if relevant)
1. magento/graphql-ce#770

### Manual testing scenarios (*)
1. Two websites

|Web Site|Store|Store View|
|---|---|---|
|Main Website<br>`base`|Main Website Store<br>`main_website_store`|Default Store View<br>`default`|
|Test Website<br>`additional`|Test Website Store<br>`test_website_store`|Test Store View<br>`test`|
2. **Account Sharing Options** has its default global setting **Share Customer Accounts** = **Per Website**

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Create Customer on the `default` Store View
**Headers**
```json
{
  "Store": "default"
}
```

**Request**
```graphql
mutation {
  createCustomer(
    input: {
      prefix: "Prince"
      firstname: "John"
      suffix: "IV"
      middlename: "Ruel"
      lastname: "Doe"
      email: "John.Doe@example.com"
      dob: "10/10/10"
      gender: 1
      password: "123123qA"
    }
  ) {
    customer {
      prefix
      firstname
      lastname
      middlename
      suffix
      email
      dob
      gender
    }
  }
}
```
2. Create Customer on the `test` Store View
**Headers**
```json
{
  "Store": "test"
}
```

**Request**
```graphql
mutation {
  createCustomer(
    input: {
      prefix: "Prince"
      firstname: "John"
      suffix: "IV"
      lastname: "Doe"
      email: "John.Doe@example.com"
      dob: "11/11/11"
      gender: 3
      password: "123123qAqA"
    }
  ) {
    customer {
      prefix
      firstname
      lastname
      middlename
      suffix
      email
      dob
      gender
    }
  }
}
```
2. Generate Customer's token for the customer on `default` Store View
**Headers**
```graphql
{
  "Store": "default"
}
```
**Request**
```graphql
mutation {
  generateCustomerToken(
    email: "John.Doe@example.com"
    password: "123123qA"
  ) {
    token
  }
}
```
3. Get Customers information from the `test` Store View using token for `default` Store Virew
**Headers**
{
  "Authorization": "Bearer xo0aqut1x5erzjv2du6vu6qbbegkjpmr",
  "Store": "ssetview"
}
**Request**
```graphql
query {
  customer {
    created_at
    default_billing
    default_shipping
    dob
    email
    firstname
    gender
    group_id
    id
    is_subscribed
    lastname
    middlename
    prefix
    suffix
    taxvat
    group_id
  }
}
```
### Expected result (*)
1. Authorization problem

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
