### PR TITLE
add Magento_QuoteGraphQl dependency to Magento_ConfigurableProductGra…

### DIFF
--- a/app/code/Magento/ConfigurableProductGraphQl/etc/module.xml
+++ b/app/code/Magento/ConfigurableProductGraphQl/etc/module.xml
@@ -12,6 +12,7 @@
             <module name="Magento_ConfigurableProduct"/>
             <module name="Magento_GraphQl"/>
             <module name="Magento_CatalogGraphQl"/>
+            <module name="Magento_QuoteGraphQl"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The `Magento_ConfigurableProductGraphQl` module has a reference to `CartItemInput`. This type is defined in `Magento_QuoteGraphQl`.

### Manual testing scenarios (*)

- Remove a couple of modules using `replace: "*"` in `composer.json`.
- Run `setup:upgrade`, modules will reorder in `app/etc/config.php` in such a way that `Magento_ConfigurableProductGraphQl` is loaded before `Magento_QuoteGraphQl`.
- GraphQL schema stitching will now fail because of wrong depdendency order.

### Questions or comments

This case is already covered by integration test `Magento\GraphQl\Controller\GraphQlControllerTest`, but it didn't catch because this test is run with all modules enabled, this wasn't the case for our project.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
