### PR TITLE
Return special_price and tier_prices in view currency

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Product/SpecialPrice.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Product/SpecialPrice.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogGraphQl\Model\Resolver\Product;
+
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Pricing\Price\FinalPrice;
+use Magento\Catalog\Pricing\Price\RegularPrice;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\Pricing\Adjustment\AdjustmentInterface;
+use Magento\Framework\Pricing\Amount\AmountInterface;
+use Magento\Framework\Pricing\PriceInfo\Factory as PriceInfoFactory;
+use Magento\Store\Api\Data\StoreInterface;
+
+/**
+ * Format a product's special price information to conform to GraphQL schema representation
+ */
+class SpecialPrice implements ResolverInterface
+{
+    /**
+     * @inheritdoc
+     *
+     * Format product's special price data to conform to GraphQL schema
+     *
+     * @param \Magento\Framework\GraphQl\Config\Element\Field $field
+     * @param ContextInterface $context
+     * @param ResolveInfo $info
+     * @param array|null $value
+     * @param array|null $args
+     * @throws \Exception
+     * @return float
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['model'])) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+
+        /** @var Product $product */
+        $product = $value['model'];
+
+        $specialPrice = $product->getPriceInfo()->getPrice('special_price');
+        return $specialPrice->getValue() ?: null;
+    }
+}

--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -72,7 +72,7 @@ interface ProductInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\
     sku: String @doc(description: "A number or code assigned to a product to identify the product, options, price, and manufacturer.")
     description: ComplexTextValue @doc(description: "Detailed information about the product. The value can include simple HTML tags.") @resolver(class: "\\Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductComplexTextAttribute")
     short_description: ComplexTextValue @doc(description: "A short description of the product. Its use depends on the theme.") @resolver(class: "\\Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductComplexTextAttribute")
-    special_price: Float @doc(description: "The discounted price of the product.")
+    special_price: Float @doc(description: "The discounted price of the product.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\SpecialPrice")
     special_from_date: String @doc(description: "The beginning date that a product has a special price.")
     special_to_date: String @doc(description: "The end date that a product has a special price.")
     attribute_set_id: Int @doc(description: "The attribute set assigned to the product.")


### PR DESCRIPTION
### Description (*)
Returns special and tier price values in the requested store currency. Prior to this fix the values were always returned in the base currency.

### Fixed Issues (if relevant)
1. magento/graphql-ce#680

### Manual testing scenarios (*)
1. Go to Stores -> All Stores and create additional Store (second column) for the same website.
2. Create the Store View for that Store
3. Navigate to Store -> Settings -> Configuration -> General -> Currency Setup and allow EURO in 4. Allowed Currencies and Save Configuration
5. Change the Scope to the second Store View and set Default Display Currency to Euro
6. Setup Currency Rates with Fixer or set manually
7. Run query products but set the proper header.
8. Set Default Display Currency to Euro in the Global Scope
```graphql
query productSearch {
  products(
    search:"simple"
    pageSize:1
  ) {
    items {
      id
      sku
      price {
        regularPrice{
          amount {
            currency
            value
          }
        }
      }
      tier_prices {
        customer_group_id
        percentage_value
        qty
        value
        website_id
      }
      special_price
    }
  }
}
```

Run query products without headers

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
