### PR TITLE
graphQl-810: test add non existent configurable product

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/AddConfigurableProductToCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/AddConfigurableProductToCartTest.php
@@ -117,8 +117,6 @@ class AddConfigurableProductToCartTest extends GraphQlAbstract
     /**
      * @magentoApiDataFixture Magento/ConfigurableProduct/_files/product_configurable_sku.php
      * @magentoApiDataFixture Magento/Checkout/_files/active_quote.php
-     * @expectedException \Exception
-     * @expectedExceptionMessage Could not add the product with SKU configurable to the shopping cart: Could not find specified product.
      */
     public function testAddNonExistentConfigurableProductVariationToCart()
     {
@@ -134,6 +132,11 @@ class AddConfigurableProductToCartTest extends GraphQlAbstract
             $parentSku,
             $sku,
             2000
+        );
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage(
+            'Could not add the product with SKU configurable to the shopping cart: Could not find specified product.'
         );
 
         $this->graphQlMutation($query);

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/AddConfigurableProductToCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/AddConfigurableProductToCartTest.php
@@ -93,6 +93,53 @@ class AddConfigurableProductToCartTest extends GraphQlAbstract
     }
 
     /**
+     * @magentoApiDataFixture Magento/ConfigurableProduct/_files/product_configurable_sku.php
+     * @magentoApiDataFixture Magento/Checkout/_files/active_quote.php
+     * @expectedException \Exception
+     * @expectedExceptionMessage Could not find a product with SKU "configurable_no_exist"
+     */
+    public function testAddNonExistentConfigurableProductParentToCart()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_order_1');
+        $parentSku = 'configurable_no_exist';
+        $sku = 'simple_20';
+
+        $query = $this->getQuery(
+            $maskedQuoteId,
+            $parentSku,
+            $sku,
+            2000
+        );
+
+        $this->graphQlMutation($query);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/ConfigurableProduct/_files/product_configurable_sku.php
+     * @magentoApiDataFixture Magento/Checkout/_files/active_quote.php
+     * @expectedException \Exception
+     * @expectedExceptionMessage Could not add the product with SKU configurable to the shopping cart: Could not find specified product.
+     */
+    public function testAddNonExistentConfigurableProductVariationToCart()
+    {
+        $searchResponse = $this->graphQlQuery($this->getFetchProductQuery('configurable'));
+        $product = current($searchResponse['products']['items']);
+
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_order_1');
+        $parentSku = $product['sku'];
+        $sku = 'simple_no_exist';
+
+        $query = $this->getQuery(
+            $maskedQuoteId,
+            $parentSku,
+            $sku,
+            2000
+        );
+
+        $this->graphQlMutation($query);
+    }
+
+    /**
      * @param string $maskedQuoteId
      * @param string $parentSku
      * @param string $sku


### PR DESCRIPTION
### Description (*)
Non existent configurable product test cases

### Fixed Issues (if relevant)
1. #810: [Test coverage] Use of addConfigurableProductsToCart with entities that do not exist
