### PR TITLE
graphQl-864: Prevent to return a shipping address until it is set on a cart

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/ShippingAddresses.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/ShippingAddresses.php
@@ -44,6 +44,10 @@ class ShippingAddresses implements ResolverInterface
         $cart = $value['model'];
 
         $addressesData = [];
+        if (!$cart->getExtensionAttributes()->getShippingAssignments()) {
+            return $addressesData;
+        }
+
         $shippingAddresses = $cart->getAllShippingAddresses();
 
         if (count($shippingAddresses)) {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetSpecifiedShippingAddressTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetSpecifiedShippingAddressTest.php
@@ -79,6 +79,22 @@ class GetSpecifiedShippingAddressTest extends GraphQlAbstract
 
     /**
      * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+     */
+    public function testShippingAddressOnCreatedEmptyCart()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+
+        $response = $this->graphQlQuery($query, [], '', $this->getHeaderMap());
+        self::assertArrayHasKey('cart', $response);
+        self::assertArrayHasKey('shipping_addresses', $response['cart']);
+
+        self::assertCount(0, $response['cart']['shipping_addresses']);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
      * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/GetSpecifiedShippingAddressTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/GetSpecifiedShippingAddressTest.php
@@ -69,6 +69,21 @@ class GetSpecifiedShippingAddressTest extends GraphQlAbstract
     }
 
     /**
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
+     */
+    public function testShippingAddressOnCreatedEmptyCart()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+
+        $response = $this->graphQlQuery($query);
+        self::assertArrayHasKey('cart', $response);
+        self::assertArrayHasKey('shipping_addresses', $response['cart']);
+
+        self::assertCount(0, $response['cart']['shipping_addresses']);
+    }
+
+    /**
      * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php


### PR DESCRIPTION
### Description (*)
Return an empty array of shipping addresses for the created empty cart until a shipping address
is set.

### Fixed Issues (if relevant)
1. #864: The shipping address contains `null` values when there's no shipping address set on a cart
