### PR TITLE
graphQl-889: base_amount marked as deprecated

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/ShippingAddress/AvailableShippingMethods.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/ShippingAddress/AvailableShippingMethods.php
@@ -98,11 +98,8 @@ class AvailableShippingMethods implements ResolverInterface
             $data['amount'] = ['value' => $data['amount'], 'currency' => $quoteCurrencyCode];
         }
 
-        if (isset($data['base_amount'])) {
-            /** @var Currency $currency */
-            $currency = $store->getBaseCurrency();
-            $data['base_amount'] = ['value' => $data['base_amount'], 'currency' => $currency->getCode()];
-        }
+        /** @deprecated The field should not be used on the storefront */
+        $data['base_amount'] = null;
 
         if (isset($data['price_excl_tax'])) {
             $data['price_excl_tax'] = ['value' => $data['price_excl_tax'], 'currency' => $quoteCurrencyCode];

--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/ShippingAddress/AvailableShippingMethods.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/ShippingAddress/AvailableShippingMethods.php
@@ -75,8 +75,7 @@ class AvailableShippingMethods implements ResolverInterface
                 );
                 $methods[] = $this->processMoneyTypeData(
                     $methodData,
-                    $cart->getQuoteCurrencyCode(),
-                    $context->getExtensionAttributes()->getStore()
+                    $cart->getQuoteCurrencyCode()
                 );
             }
         }
@@ -88,11 +87,10 @@ class AvailableShippingMethods implements ResolverInterface
      *
      * @param array $data
      * @param string $quoteCurrencyCode
-     * @param StoreInterface $store
      * @return array
      * @throws NoSuchEntityException
      */
-    private function processMoneyTypeData(array $data, string $quoteCurrencyCode, StoreInterface $store): array
+    private function processMoneyTypeData(array $data, string $quoteCurrencyCode): array
     {
         if (isset($data['amount'])) {
             $data['amount'] = ['value' => $data['amount'], 'currency' => $quoteCurrencyCode];

--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/ShippingAddress/SelectedShippingMethod.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/ShippingAddress/SelectedShippingMethod.php
@@ -58,10 +58,8 @@ class SelectedShippingMethod implements ResolverInterface
                     'value' => $address->getShippingAmount(),
                     'currency' => $address->getQuote()->getQuoteCurrencyCode(),
                 ],
-                'base_amount' => [
-                    'value' => $address->getBaseShippingAmount(),
-                    'currency' => $currency->getCode(),
-                ],
+                /** @deprecated The field should not be used on the storefront */
+                'base_amount' => null,
             ];
         } else {
             $data = [
@@ -70,6 +68,7 @@ class SelectedShippingMethod implements ResolverInterface
                 'carrier_title' => $carrierTitle,
                 'method_title' => $methodTitle,
                 'amount' => null,
+                /** @deprecated The field should not be used on the storefront */
                 'base_amount' => null,
             ];
         }

--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/ShippingAddress/SelectedShippingMethod.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/ShippingAddress/SelectedShippingMethod.php
@@ -46,9 +46,6 @@ class SelectedShippingMethod implements ResolverInterface
                 }
             }
 
-            /** @var Currency $currency */
-            $currency = $context->getExtensionAttributes()->getStore()->getBaseCurrency();
-
             $data = [
                 'carrier_code' => $carrierCode,
                 'method_code' => $methodCode,

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -244,7 +244,7 @@ type SelectedShippingMethod {
     carrier_title: String
     method_title: String
     amount: Money
-    base_amount: Money
+    base_amount: Money @deprecated(reason: "The field should not be used on the storefront")
 }
 
 type AvailableShippingMethod {
@@ -254,7 +254,7 @@ type AvailableShippingMethod {
     method_title: String @doc(description: "Could be null if method is not available")
     error_message: String
     amount: Money!
-    base_amount: Money @doc(description: "Could be null if method is not available")
+    base_amount: Money @deprecated(reason: "The field should not be used on the storefront")
     price_excl_tax: Money!
     price_incl_tax: Money!
     available: Boolean!

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetAvailableShippingMethodsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetAvailableShippingMethodsTest.php
@@ -62,10 +62,6 @@ class GetAvailableShippingMethodsTest extends GraphQlAbstract
                 'value' => 10,
                 'currency' => 'USD',
             ],
-            'base_amount' => [
-                'value' => 10,
-                'currency' => 'USD',
-            ],
             'carrier_code' => 'flatrate',
             'carrier_title' => 'Flat Rate',
             'error_message' => '',
@@ -173,10 +169,6 @@ query {
     shipping_addresses {
         available_shipping_methods {
           amount {
-            value
-            currency
-          }
-          base_amount {
             value
             currency
           }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetSelectedShippingMethodTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetSelectedShippingMethodTest.php
@@ -78,14 +78,6 @@ class GetSelectedShippingMethodTest extends GraphQlAbstract
         self::assertEquals(10, $amount['value']);
         self::assertArrayHasKey('currency', $amount);
         self::assertEquals('USD', $amount['currency']);
-
-        self::assertArrayHasKey('base_amount', $shippingAddress['selected_shipping_method']);
-        $baseAmount = $shippingAddress['selected_shipping_method']['base_amount'];
-
-        self::assertArrayHasKey('value', $baseAmount);
-        self::assertEquals(10, $baseAmount['value']);
-        self::assertArrayHasKey('currency', $baseAmount);
-        self::assertEquals('USD', $baseAmount['currency']);
     }
 
     /**
@@ -188,7 +180,6 @@ class GetSelectedShippingMethodTest extends GraphQlAbstract
         self::assertNull($shippingAddress['selected_shipping_method']['carrier_title']);
         self::assertNull($shippingAddress['selected_shipping_method']['method_title']);
         self::assertNull($shippingAddress['selected_shipping_method']['amount']);
-        self::assertNull($shippingAddress['selected_shipping_method']['base_amount']);
     }
 
     /**
@@ -237,10 +228,6 @@ class GetSelectedShippingMethodTest extends GraphQlAbstract
         carrier_title
         method_title
         amount {
-            value
-            currency
-        }
-        base_amount {
             value
             currency
         }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetOfflineShippingMethodsOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetOfflineShippingMethodsOnCartTest.php
@@ -53,7 +53,6 @@ class SetOfflineShippingMethodsOnCartTest extends GraphQlAbstract
      * @param string $carrierTitle
      * @param string $methodTitle
      * @param array $amount
-     * @param array $baseAmount
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      * @dataProvider offlineShippingMethodDataProvider
      */
@@ -62,8 +61,7 @@ class SetOfflineShippingMethodsOnCartTest extends GraphQlAbstract
         string $methodCode,
         string $carrierTitle,
         string $methodTitle,
-        array $amount,
-        array $baseAmount
+        array $amount
     ) {
         $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
 
@@ -96,9 +94,6 @@ class SetOfflineShippingMethodsOnCartTest extends GraphQlAbstract
 
         self::assertArrayHasKey('amount', $shippingAddress['selected_shipping_method']);
         self::assertEquals($amount, $shippingAddress['selected_shipping_method']['amount']);
-
-        self::assertArrayHasKey('base_amount', $shippingAddress['selected_shipping_method']);
-        self::assertEquals($baseAmount, $shippingAddress['selected_shipping_method']['base_amount']);
     }
 
     /**
@@ -113,7 +108,6 @@ class SetOfflineShippingMethodsOnCartTest extends GraphQlAbstract
                 'Flat Rate',
                 'Fixed',
                 ['value' => 10, 'currency' => 'USD'],
-                ['value' => 10, 'currency' => 'USD'],
             ],
             'tablerate_bestway' => [
                 'tablerate',
@@ -121,14 +115,12 @@ class SetOfflineShippingMethodsOnCartTest extends GraphQlAbstract
                 'Best Way',
                 'Table Rate',
                 ['value' => 10, 'currency' => 'USD'],
-                ['value' => 10, 'currency' => 'USD'],
             ],
             'freeshipping_freeshipping' => [
                 'freeshipping',
                 'freeshipping',
                 'Free Shipping',
                 'Free',
-                ['value' => 0, 'currency' => 'USD'],
                 ['value' => 0, 'currency' => 'USD'],
             ],
         ];
@@ -163,10 +155,6 @@ mutation {
           carrier_title
           method_title
           amount {
-            value
-            currency
-          }
-          base_amount {
             value
             currency
           }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetShippingMethodsOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetShippingMethodsOnCartTest.php
@@ -85,14 +85,6 @@ class SetShippingMethodsOnCartTest extends GraphQlAbstract
         self::assertEquals(10, $amount['value']);
         self::assertArrayHasKey('currency', $amount);
         self::assertEquals('USD', $amount['currency']);
-
-        self::assertArrayHasKey('base_amount', $shippingAddress['selected_shipping_method']);
-        $baseAmount = $shippingAddress['selected_shipping_method']['base_amount'];
-
-        self::assertArrayHasKey('value', $baseAmount);
-        self::assertEquals(10, $baseAmount['value']);
-        self::assertArrayHasKey('currency', $baseAmount);
-        self::assertEquals('USD', $baseAmount['currency']);
     }
 
     /**
@@ -376,10 +368,6 @@ mutation {
           carrier_title
           method_title
           amount {
-            value
-            currency
-          }
-          base_amount {
             value
             currency
           }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/GetAvailableShippingMethodsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/GetAvailableShippingMethodsTest.php
@@ -54,10 +54,6 @@ class GetAvailableShippingMethodsTest extends GraphQlAbstract
                 'value' => 10,
                 'currency' => 'USD',
             ],
-            'base_amount' => [
-                'value' => 10,
-                'currency' => 'USD',
-            ],
             'carrier_code' => 'flatrate',
             'carrier_title' => 'Flat Rate',
             'error_message' => '',
@@ -141,10 +137,6 @@ query {
     shipping_addresses {
         available_shipping_methods {
           amount {
-            value
-            currency
-          }
-          base_amount {
             value
             currency
           }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/GetSelectedShippingMethodTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/GetSelectedShippingMethodTest.php
@@ -70,14 +70,6 @@ class GetSelectedShippingMethodTest extends GraphQlAbstract
         self::assertEquals(10, $amount['value']);
         self::assertArrayHasKey('currency', $amount);
         self::assertEquals('USD', $amount['currency']);
-
-        self::assertArrayHasKey('base_amount', $shippingAddress['selected_shipping_method']);
-        $baseAmount = $shippingAddress['selected_shipping_method']['base_amount'];
-
-        self::assertArrayHasKey('value', $baseAmount);
-        self::assertEquals(10, $baseAmount['value']);
-        self::assertArrayHasKey('currency', $baseAmount);
-        self::assertEquals('USD', $baseAmount['currency']);
     }
 
     /**
@@ -158,7 +150,6 @@ class GetSelectedShippingMethodTest extends GraphQlAbstract
         self::assertNull($shippingAddress['selected_shipping_method']['carrier_title']);
         self::assertNull($shippingAddress['selected_shipping_method']['method_title']);
         self::assertNull($shippingAddress['selected_shipping_method']['amount']);
-        self::assertNull($shippingAddress['selected_shipping_method']['base_amount']);
     }
 
     /**
@@ -192,10 +183,6 @@ class GetSelectedShippingMethodTest extends GraphQlAbstract
         carrier_title
         method_title
         amount {
-            value
-            currency
-        }
-        base_amount {
             value
             currency
         }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetOfflineShippingMethodsOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetOfflineShippingMethodsOnCartTest.php
@@ -45,7 +45,6 @@ class SetOfflineShippingMethodsOnCartTest extends GraphQlAbstract
      * @param string $carrierTitle
      * @param string $methodTitle
      * @param array $amount
-     * @param array $baseAmount
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      * @dataProvider offlineShippingMethodDataProvider
      */
@@ -54,8 +53,7 @@ class SetOfflineShippingMethodsOnCartTest extends GraphQlAbstract
         string $methodCode,
         string $carrierTitle,
         string $methodTitle,
-        array $amount,
-        array $baseAmount
+        array $amount
     ) {
         $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
 
@@ -88,9 +86,6 @@ class SetOfflineShippingMethodsOnCartTest extends GraphQlAbstract
 
         self::assertArrayHasKey('amount', $shippingAddress['selected_shipping_method']);
         self::assertEquals($amount, $shippingAddress['selected_shipping_method']['amount']);
-
-        self::assertArrayHasKey('base_amount', $shippingAddress['selected_shipping_method']);
-        self::assertEquals($baseAmount, $shippingAddress['selected_shipping_method']['base_amount']);
     }
 
     /**
@@ -105,7 +100,6 @@ class SetOfflineShippingMethodsOnCartTest extends GraphQlAbstract
                 'Flat Rate',
                 'Fixed',
                 ['value' => 10, 'currency' => 'USD'],
-                ['value' => 10, 'currency' => 'USD'],
             ],
             'tablerate_bestway' => [
                 'tablerate',
@@ -113,14 +107,12 @@ class SetOfflineShippingMethodsOnCartTest extends GraphQlAbstract
                 'Best Way',
                 'Table Rate',
                 ['value' => 10, 'currency' => 'USD'],
-                ['value' => 10, 'currency' => 'USD'],
             ],
             'freeshipping_freeshipping' => [
                 'freeshipping',
                 'freeshipping',
                 'Free Shipping',
                 'Free',
-                ['value' => 0, 'currency' => 'USD'],
                 ['value' => 0, 'currency' => 'USD'],
             ],
         ];
@@ -155,10 +147,6 @@ mutation {
           carrier_title
           method_title
           amount {
-            value
-            currency
-          }
-          base_amount {
             value
             currency
           }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetShippingMethodsOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetShippingMethodsOnCartTest.php
@@ -77,14 +77,6 @@ class SetShippingMethodsOnCartTest extends GraphQlAbstract
         self::assertEquals(10, $amount['value']);
         self::assertArrayHasKey('currency', $amount);
         self::assertEquals('USD', $amount['currency']);
-
-        self::assertArrayHasKey('base_amount', $shippingAddress['selected_shipping_method']);
-        $baseAmount = $shippingAddress['selected_shipping_method']['base_amount'];
-
-        self::assertArrayHasKey('value', $baseAmount);
-        self::assertEquals(10, $baseAmount['value']);
-        self::assertArrayHasKey('currency', $baseAmount);
-        self::assertEquals('USD', $baseAmount['currency']);
     }
 
     /**
@@ -387,10 +379,6 @@ mutation {
           carrier_title
           method_title
           amount {
-            value
-            currency
-          }
-          base_amount {
             value
             currency
           }


### PR DESCRIPTION
### Description (*)
AvailableShippingMethod and SelectedShippingMethod base_amount marked as deprecated

### Fixed Issues (if relevant)
1. #889: [Checkout] Eliminate base_amount
