### PR TITLE
graphQl-891: refactored the customer notes field in the shipping address

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Cart/SetShippingAddressesOnCart.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/SetShippingAddressesOnCart.php
@@ -53,6 +53,10 @@ class SetShippingAddressesOnCart implements SetShippingAddressesOnCartInterface
         $customerAddressId = $shippingAddressInput['customer_address_id'] ?? null;
         $addressInput = $shippingAddressInput['address'] ?? null;
 
+        if ($addressInput) {
+            $addressInput['customer_notes'] = $shippingAddressInput['customer_notes'] ?? '';
+        }
+
         if (null === $customerAddressId && null === $addressInput) {
             throw new GraphQlInputException(
                 __('The shipping address must contain either "customer_address_id" or "address".')

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -85,6 +85,7 @@ input SetShippingAddressesOnCartInput {
 input ShippingAddressInput {
     customer_address_id: Int # If provided then will be used address from address book
     address: CartAddressInput
+    customer_notes: String
 }
 
 input SetBillingAddressOnCartInput {
@@ -210,7 +211,6 @@ interface CartAddressInterface @typeResolver(class: "\\Magento\\QuoteGraphQl\\Mo
     postcode: String
     country: CartAddressCountry
     telephone: String
-    customer_notes: String
 }
 
 type ShippingCartAddress implements CartAddressInterface {
@@ -218,9 +218,11 @@ type ShippingCartAddress implements CartAddressInterface {
     selected_shipping_method: SelectedShippingMethod @resolver(class: "\\Magento\\QuoteGraphQl\\Model\\Resolver\\ShippingAddress\\SelectedShippingMethod")
     items_weight: Float
     cart_items: [CartItemQuantity]
+    customer_notes: String
 }
 
 type BillingCartAddress implements CartAddressInterface {
+    customer_notes: String @deprecated (reason: "The field is used only in shipping address")
 }
 
 type CartItemQuantity {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetShippingAddressOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetShippingAddressOnCartTest.php
@@ -84,6 +84,7 @@ mutation {
             telephone: "88776655"
             save_in_address_book: false
           }
+          customer_notes: "Test note"
         }
       ]
     }
@@ -102,6 +103,7 @@ mutation {
           code
         }
         __typename
+        customer_notes
       }
     }
   }
@@ -671,7 +673,8 @@ QUERY;
             ['response_field' => 'postcode', 'expected_value' => '887766'],
             ['response_field' => 'telephone', 'expected_value' => '88776655'],
             ['response_field' => 'country', 'expected_value' => ['code' => 'US', 'label' => 'US']],
-            ['response_field' => '__typename', 'expected_value' => 'ShippingCartAddress']
+            ['response_field' => '__typename', 'expected_value' => 'ShippingCartAddress'],
+            ['response_field' => 'customer_notes', 'expected_value' => 'Test note']
         ];
 
         $this->assertResponseFields($shippingAddressResponse, $assertionMap);

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetShippingAddressOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetShippingAddressOnCartTest.php
@@ -55,6 +55,7 @@ mutation {
             telephone: "88776655"
             save_in_address_book: false
           }
+          customer_notes: "Test note"
         }
       ]
     }
@@ -73,6 +74,7 @@ mutation {
           label
         }
         __typename
+        customer_notes
       }
     }
   }
@@ -527,7 +529,8 @@ QUERY;
             ['response_field' => 'postcode', 'expected_value' => '887766'],
             ['response_field' => 'telephone', 'expected_value' => '88776655'],
             ['response_field' => 'country', 'expected_value' => ['code' => 'US', 'label' => 'US']],
-            ['response_field' => '__typename', 'expected_value' => 'ShippingCartAddress']
+            ['response_field' => '__typename', 'expected_value' => 'ShippingCartAddress'],
+            ['response_field' => 'customer_notes', 'expected_value' => 'Test note']
         ];
 
         $this->assertResponseFields($shippingAddressResponse, $assertionMap);


### PR DESCRIPTION
### Description (*)
Refactored the shipping address `customer_notes` field and added CRUD support of it.

### Fixed Issues (if relevant)
1. #891: [Checkout] Add support for customer_notes in shipping address
