### PR TITLE
Add input validation for authorizenet_acceptjs payment method

### DIFF
--- a/app/code/Magento/AuthorizenetGraphQl/Model/AuthorizenetDataProvider.php
+++ b/app/code/Magento/AuthorizenetGraphQl/Model/AuthorizenetDataProvider.php
@@ -9,6 +9,7 @@ namespace Magento\AuthorizenetGraphQl\Model;
 
 use Magento\QuoteGraphQl\Model\Cart\Payment\AdditionalDataProviderInterface;
 use Magento\Framework\Stdlib\ArrayManager;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 
 /**
  * SetPaymentMethod additional data provider model for Authorizenet payment method
@@ -36,10 +37,32 @@ class AuthorizenetDataProvider implements AdditionalDataProviderInterface
      *
      * @param array $data
      * @return array
+     * @throws GraphQlInputException
      */
     public function getData(array $data): array
     {
-        $additionalData = $this->arrayManager->get(static::PATH_ADDITIONAL_DATA, $data) ?? [];
+        if (!isset($data[self::PATH_ADDITIONAL_DATA])) {
+            throw new GraphQlInputException(
+                __('Required parameter "authorizenet_acceptjs" for "payment_method" is missing.')
+            );
+        }
+        if (!isset($data[self::PATH_ADDITIONAL_DATA]['opaque_data_descriptor'])) {
+            throw new GraphQlInputException(
+                __('Required parameter "opaque_data_descriptor" for "authorizenet_acceptjs" is missing.')
+            );
+        }
+        if (!isset($data[self::PATH_ADDITIONAL_DATA]['opaque_data_value'])) {
+            throw new GraphQlInputException(
+                __('Required parameter "opaque_data_value" for "authorizenet_acceptjs" is missing.')
+            );
+        }
+        if (!isset($data[self::PATH_ADDITIONAL_DATA]['cc_last_4'])) {
+            throw new GraphQlInputException(
+                __('Required parameter "cc_last_4" for "authorizenet_acceptjs" is missing.')
+            );
+        }
+
+        $additionalData = $this->arrayManager->get(static::PATH_ADDITIONAL_DATA, $data);
         foreach ($additionalData as $key => $value) {
             $additionalData[$this->convertSnakeCaseToCamelCase($key)] = $value;
             unset($additionalData[$key]);


### PR DESCRIPTION
### Description (*)
Add input validation for `authorizenet_acceptjs` payment method. Ensures actionable error messages are returned when the required input is missing.

### Fixed Issues (if relevant)
1. magento/graphql-ce#774

### Manual testing scenarios (*)
1. Create cart
2. Add product to cart
3. Set shipping address and shipping method (if cart is not virtual)
4. Set billing address
5. 
```graphql
mutation {
  setPaymentMethodOnCart(input:{
    cart_id:"{$maskedQuoteId}"
    payment_method:{
      code:"authorizenet_acceptjs"
    }
  }) {
    cart {
      selected_payment_method {
        code
      }
    }
  }
}
```
or
```graphql
mutation {
  setPaymentMethodOnCart(input:{
    cart_id:"{$maskedQuoteId}"
    payment_method:{
      code:"authorizenet_acceptjs"
      authorizenet_acceptjs: {}
    }
  }) {
    cart {
      selected_payment_method {
        code
      }
    }
  }
}
```

**Expected Result:**

Example 1: `Required parameter "authorizenet_acceptjs" for "payment_method" is missing.`

Example 2: `Required parameter "MISSING_PARAM" for "authorizenet_acceptjs" is missing.`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
