### PR TITLE
Deprecate setPaymentMethodAndPlaceOrderMutation

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/SetPaymentAndPlaceOrder.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/SetPaymentAndPlaceOrder.php
@@ -20,7 +20,11 @@ use Magento\QuoteGraphQl\Model\Cart\SetPaymentMethodOnCart;
 use Magento\Sales\Api\OrderRepositoryInterface;
 
 /**
- * @inheritdoc
+ * Resolver for setting payment method and placing order
+ *
+ * @deprecated Should use setPaymentMethodOnCart and placeOrder mutations in single request.
+ * @see \Magento\QuoteGraphQl\Model\Resolver\SetPaymentMethodOnCart
+ * @see \Magento\QuoteGraphQl\Model\Resolver\PlaceOrder
  */
 class SetPaymentAndPlaceOrder implements ResolverInterface
 {

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -18,7 +18,7 @@ type Mutation {
     setShippingMethodsOnCart(input: SetShippingMethodsOnCartInput): SetShippingMethodsOnCartOutput @resolver(class: "\\Magento\\QuoteGraphQl\\Model\\Resolver\\SetShippingMethodsOnCart")
     setPaymentMethodOnCart(input: SetPaymentMethodOnCartInput): SetPaymentMethodOnCartOutput @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\SetPaymentMethodOnCart")
     setGuestEmailOnCart(input: SetGuestEmailOnCartInput): SetGuestEmailOnCartOutput @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\SetGuestEmailOnCart")
-    setPaymentMethodAndPlaceOrder(input: SetPaymentMethodAndPlaceOrderInput): PlaceOrderOutput @resolver(class: "\\Magento\\QuoteGraphQl\\Model\\Resolver\\SetPaymentAndPlaceOrder")
+    setPaymentMethodAndPlaceOrder(input: SetPaymentMethodAndPlaceOrderInput): PlaceOrderOutput @deprecated(reason: "Should use setPaymentMethodOnCart and placeOrder mutations in single request.") @resolver(class: "\\Magento\\QuoteGraphQl\\Model\\Resolver\\SetPaymentAndPlaceOrder")
     placeOrder(input: PlaceOrderInput): PlaceOrderOutput @resolver(class: "\\Magento\\QuoteGraphQl\\Model\\Resolver\\PlaceOrder")
 }
 

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetPaymentMethodAndPlaceOrderTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/SetPaymentMethodAndPlaceOrderTest.php
@@ -78,9 +78,14 @@ class SetPaymentMethodAndPlaceOrderTest extends GraphQlAbstract
         $query = $this->getQuery($maskedQuoteId, $methodCode);
         $response = $this->graphQlMutation($query, [], '', $this->getHeaderMap());
 
-        self::assertArrayHasKey('setPaymentMethodAndPlaceOrder', $response);
-        self::assertArrayHasKey('order', $response['setPaymentMethodAndPlaceOrder']);
-        self::assertArrayHasKey('order_id', $response['setPaymentMethodAndPlaceOrder']['order']);
+        self::assertArrayHasKey('setPaymentMethodOnCart', $response);
+        self::assertArrayHasKey('cart', $response['setPaymentMethodOnCart']);
+        self::assertArrayHasKey('selected_payment_method', $response['setPaymentMethodOnCart']['cart']);
+        self::assertArrayHasKey('code', $response['setPaymentMethodOnCart']['cart']['selected_payment_method']);
+        self::assertEquals($methodCode, $response['setPaymentMethodOnCart']['cart']['selected_payment_method']['code']);
+
+        self::assertArrayHasKey('order', $response['placeOrder']);
+        self::assertArrayHasKey('order_id', $response['placeOrder']['order']);
     }
 
     /**
@@ -116,9 +121,14 @@ class SetPaymentMethodAndPlaceOrderTest extends GraphQlAbstract
         $query = $this->getQuery($maskedQuoteId, $methodCode);
         $response = $this->graphQlMutation($query, [], '', $this->getHeaderMap());
 
-        self::assertArrayHasKey('setPaymentMethodAndPlaceOrder', $response);
-        self::assertArrayHasKey('order', $response['setPaymentMethodAndPlaceOrder']);
-        self::assertArrayHasKey('order_id', $response['setPaymentMethodAndPlaceOrder']['order']);
+        self::assertArrayHasKey('setPaymentMethodOnCart', $response);
+        self::assertArrayHasKey('cart', $response['setPaymentMethodOnCart']);
+        self::assertArrayHasKey('selected_payment_method', $response['setPaymentMethodOnCart']['cart']);
+        self::assertArrayHasKey('code', $response['setPaymentMethodOnCart']['cart']['selected_payment_method']);
+        self::assertEquals($methodCode, $response['setPaymentMethodOnCart']['cart']['selected_payment_method']['code']);
+
+        self::assertArrayHasKey('order', $response['placeOrder']);
+        self::assertArrayHasKey('order_id', $response['placeOrder']['order']);
     }
 
     /**
@@ -224,12 +234,25 @@ class SetPaymentMethodAndPlaceOrderTest extends GraphQlAbstract
     ) : string {
         return <<<QUERY
 mutation {
-  setPaymentMethodAndPlaceOrder(input: {
-      cart_id: "$maskedQuoteId"
+  setPaymentMethodOnCart(
+    input: {
+      cart_id: "{$maskedQuoteId}"
       payment_method: {
-          code: "$methodCode"
+        code: "{$methodCode}"
       }
-  }) {    
+    }
+  ) {
+    cart {
+      selected_payment_method {
+        code
+      }
+    }
+  }
+  placeOrder(
+    input: {
+      cart_id: "{$maskedQuoteId}"
+    }
+  ) {
     order {
       order_id
     }


### PR DESCRIPTION
### Description (*)
The #723 introduces setPaymentAndPlaceOrder mutation to set the payment method for the cart and place an order via the same mutation.
After internal discussion, we decided to remove setPaymentAndPlaceOrder as GraphQL guarantees that multiple mutations will be executed one by one via one HTTP request https://graphql.org/learn/queries/.

### Fixed Issues (if relevant)
1. magento/graphql-ce#875

### Manual testing scenarios (*)
1. Create empty cart
2. Add product to cart
3. Set shipping address and method (if cart is not virtual)
4. Set billing address
5. 
```graphql
mutation {
  setPaymentMethodOnCart(
    input: {
      cart_id: "{$maskedQuoteId}"
      payment_method: {
        code: "{$methodCode}"
      }
    }
  ) {
    cart {
      selected_payment_method {
        code
      }
    }
  }
  placeOrder(
    input: {
      cart_id: "{$maskedQuoteId}"
    }
  ) {
    order {
      order_id
    }
  }
}
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
