### PR TITLE
Added @deprecated to custom_attributes on CustomerAddress via directi…

### DIFF
--- a/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
@@ -36,7 +36,7 @@ input CustomerAddressInput {
     prefix: String @doc(description: "An honorific, such as Dr., Mr., or Mrs.")
     suffix: String @doc(description: "A value such as Sr., Jr., or III")
     vat_id: String @doc(description: "The customer's Tax/VAT number (for corporate customers)")
-    custom_attributes: [CustomerAddressAttributeInput] @doc(description: "Address custom attributes")
+    custom_attributes: [CustomerAddressAttributeInput] @doc(description: " Address custom attributes Deprecated: Custom attributes should not be put into custom_attributes container.")
 }
 
 input CustomerAddressRegionInput @doc(description: "CustomerAddressRegionInput defines the customer's state or province") {
@@ -115,7 +115,7 @@ type CustomerAddress @doc(description: "CustomerAddress contains detailed inform
     vat_id: String @doc(description: "The customer's Tax/VAT number (for corporate customers)")
     default_shipping: Boolean @doc(description: "Indicates whether the address is the default shipping address")
     default_billing: Boolean @doc(description: "Indicates whether the address is the default billing address")
-    custom_attributes: [CustomerAddressAttribute] @doc(description: "Address custom attributes")
+    custom_attributes: [CustomerAddressAttribute] @deprecated(reason: "Custom attributes should not be put into custom_attributes container.") @doc(description: "Address custom attributes")
     extension_attributes: [CustomerAddressAttribute] @doc(description: "Address extension attributes")
 }
 

--- a/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
@@ -36,7 +36,7 @@ input CustomerAddressInput {
     prefix: String @doc(description: "An honorific, such as Dr., Mr., or Mrs.")
     suffix: String @doc(description: "A value such as Sr., Jr., or III")
     vat_id: String @doc(description: "The customer's Tax/VAT number (for corporate customers)")
-    custom_attributes: [CustomerAddressAttributeInput] @doc(description: " Address custom attributes Deprecated: Custom attributes should not be put into custom_attributes container.")
+    custom_attributes: [CustomerAddressAttributeInput] @doc(description: "Deprecated: Custom attributes should not be put into container.")
 }
 
 input CustomerAddressRegionInput @doc(description: "CustomerAddressRegionInput defines the customer's state or province") {
@@ -115,7 +115,7 @@ type CustomerAddress @doc(description: "CustomerAddress contains detailed inform
     vat_id: String @doc(description: "The customer's Tax/VAT number (for corporate customers)")
     default_shipping: Boolean @doc(description: "Indicates whether the address is the default shipping address")
     default_billing: Boolean @doc(description: "Indicates whether the address is the default billing address")
-    custom_attributes: [CustomerAddressAttribute] @deprecated(reason: "Custom attributes should not be put into custom_attributes container.") @doc(description: "Address custom attributes")
+    custom_attributes: [CustomerAddressAttribute] @deprecated(reason: "Custom attributes should not be put into container")
     extension_attributes: [CustomerAddressAttribute] @doc(description: "Address extension attributes")
 }
 


### PR DESCRIPTION
…ve and on CustomerAddressInput via @doc

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
I've added the required deprecated directive to CustomerAddress and CustomerAddress(via @doc).


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Access graphql using either the chromeiQl or any other graphql IDE.
2. Open documentation tabs and search for CustomerAddress and under Deprecated fields you shoud able to see the custom_attributes field ant a the reason for the deprecation notice.
3. Search for CustomerAddressInput under documentation and the custom_attributes will have a deprecated notice on its description

### Questions or comments
Since the custom_attributes field was not present on any of the web api tests there was no reason to change any of those files responsible for testing the CustomerGraphql module.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
