### PR TITLE
Customer group_id deprecation

### DIFF
--- a/app/code/Magento/CustomerGraphQl/Model/Customer/ExtractCustomerData.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/ExtractCustomerData.php
@@ -101,7 +101,8 @@ class ExtractCustomerData
             }
         }
         $customerData = array_merge($customerData, $customAttributes);
-
+        //Field is deprecated and should not be exposed on storefront.
+        $customerData['group_id'] = null;
         $customerData['model'] = $customer;
         return $customerData;
     }

--- a/app/code/Magento/CustomerGraphQl/Model/Customer/GetCustomer.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/GetCustomer.php
@@ -92,6 +92,6 @@ class GetCustomer
         if ($confirmationStatus === AccountManagementInterface::ACCOUNT_CONFIRMATION_REQUIRED) {
             throw new GraphQlAuthenticationException(__("This account isn't confirmed. Verify and try again."));
         }
-        return $customer;
+        return $customer->setGroupId(null);
     }
 }

--- a/app/code/Magento/CustomerGraphQl/Model/Customer/GetCustomer.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/GetCustomer.php
@@ -92,6 +92,6 @@ class GetCustomer
         if ($confirmationStatus === AccountManagementInterface::ACCOUNT_CONFIRMATION_REQUIRED) {
             throw new GraphQlAuthenticationException(__("This account isn't confirmed. Verify and try again."));
         }
-        return $customer->setGroupId(null);
+        return $customer;
     }
 }

--- a/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
@@ -78,7 +78,7 @@ type RevokeCustomerTokenOutput {
 
 type Customer @doc(description: "Customer defines the customer name and address and other details") {
     created_at: String @doc(description: "Timestamp indicating when the account was created")
-    group_id: Int @doc(description: "The group assigned to the user. Default values are 0 (Not logged in), 1 (General), 2 (Wholesale), and 3 (Retailer)")
+    group_id: Int @doc(description: "The group assigned to the user. Default values are 0 (Not logged in), 1 (General), 2 (Wholesale), and 3 (Retailer)") @deprecated(reason: "Customer group should not be exposed in the storefront scenarios.")
     prefix: String @doc(description: "An honorific, such as Dr., Mr., or Mrs.")
     firstname: String @doc(description: "The customer's first name")
     middlename: String @doc(description: "The customer's middle name")

--- a/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
@@ -78,7 +78,7 @@ type RevokeCustomerTokenOutput {
 
 type Customer @doc(description: "Customer defines the customer name and address and other details") {
     created_at: String @doc(description: "Timestamp indicating when the account was created")
-    group_id: Int @doc(description: "The group assigned to the user. Default values are 0 (Not logged in), 1 (General), 2 (Wholesale), and 3 (Retailer)") @deprecated(reason: "Customer group should not be exposed in the storefront scenarios.")
+    group_id: Int @deprecated(reason: "Customer group should not be exposed in the storefront scenarios")
     prefix: String @doc(description: "An honorific, such as Dr., Mr., or Mrs.")
     firstname: String @doc(description: "The customer's first name")
     middlename: String @doc(description: "The customer's middle name")


### PR DESCRIPTION
### Description (*)
Added a deprecated anotation to the graphql schema and changed the model of the GraphQL to only return null value.

### Fixed Issues (if relevant)
1. #910 [Customer] Deprecate group_id in Customer
