### PR TITLE
graphQl-907: [Customer] Deprecate customer_id in CustomerAddress

### DIFF
--- a/app/code/Magento/CustomerGraphQl/Model/Customer/Address/ExtractCustomerAddressData.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/Address/ExtractCustomerAddressData.php
@@ -125,6 +125,8 @@ class ExtractCustomerAddressData
         }
         $addressData = array_merge($addressData, $customAttributes);
 
+        $addressData['customer_id'] = null;
+
         return $addressData;
     }
 }

--- a/app/code/Magento/CustomerGraphQl/Model/Customer/ExtractCustomerData.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/ExtractCustomerData.php
@@ -103,6 +103,8 @@ class ExtractCustomerData
         $customerData = array_merge($customerData, $customAttributes);
 
         $customerData['model'] = $customer;
+        $customerData['id'] = null;
+
         return $customerData;
     }
 }

--- a/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
@@ -89,7 +89,7 @@ type Customer @doc(description: "Customer defines the customer name and address 
     default_shipping: String @doc(description: "The ID assigned to the shipping address")
     dob: String @doc(description: "The customer's date of birth")
     taxvat: String @doc(description: "The customer's Tax/VAT number (for corporate customers)")
-    id: Int @doc(description: "The ID assigned to the customer")
+    id: Int @doc(description: "The ID assigned to the customer") @deprecated(reason: "id is not needed as part of Customer because on server side it can be identified based on customer token used for authentication. There is no need to know customer ID on the client side.")
     is_subscribed: Boolean @doc(description: "Indicates whether the customer is subscribed to the company's newsletter") @resolver(class: "\\Magento\\CustomerGraphQl\\Model\\Resolver\\IsSubscribed")
     addresses: [CustomerAddress] @doc(description: "An array containing the customer's shipping and billing addresses") @resolver(class: "\\Magento\\CustomerGraphQl\\Model\\Resolver\\CustomerAddresses")
     gender: Int @doc(description: "The customer's gender(Male - 1, Female - 2)")
@@ -97,7 +97,7 @@ type Customer @doc(description: "Customer defines the customer name and address 
 
 type CustomerAddress @doc(description: "CustomerAddress contains detailed information about a customer's billing and shipping addresses"){
     id: Int @doc(description: "The ID assigned to the address object")
-    customer_id: Int @doc(description: "The customer ID")
+    customer_id: Int @doc(description: "The customer ID") @deprecated(reason: "customer_id is not needed as part of CustomerAddress, address ID (id) is unique identifier for the addresses.")
     region: CustomerAddressRegion @doc(description: "An object containing the region name, region code, and region ID")
     region_id: Int @doc(description: "A number that uniquely identifies the state, province, or other area")
     country_id: String @doc(description: "The customer's country")

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CreateCustomerAddressTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CreateCustomerAddressTest.php
@@ -43,7 +43,6 @@ class CreateCustomerAddressTest extends GraphQlAbstract
      */
     public function testCreateCustomerAddress()
     {
-        $customerId = 1;
         $newAddress = [
             'region' => [
                 'region' => 'Arizona',
@@ -124,11 +123,12 @@ MUTATION;
         $response = $this->graphQlMutation($mutation, [], '', $this->getCustomerAuthHeaders($userName, $password));
         $this->assertArrayHasKey('createCustomerAddress', $response);
         $this->assertArrayHasKey('customer_id', $response['createCustomerAddress']);
-        $this->assertEquals($customerId, $response['createCustomerAddress']['customer_id']);
+        $this->assertEquals(null, $response['createCustomerAddress']['customer_id']);
         $this->assertArrayHasKey('id', $response['createCustomerAddress']);
 
         $address = $this->addressRepository->getById($response['createCustomerAddress']['id']);
         $this->assertEquals($address->getId(), $response['createCustomerAddress']['id']);
+        $address->setCustomerId(null);
         $this->assertCustomerAddressesFields($address, $response['createCustomerAddress']);
         $this->assertCustomerAddressesFields($address, $newAddress);
     }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CreateCustomerTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CreateCustomerTest.php
@@ -68,6 +68,7 @@ mutation {
 QUERY;
         $response = $this->graphQlMutation($query);
 
+        $this->assertEquals(null, $response['createCustomer']['customer']['id']);
         $this->assertEquals($newFirstname, $response['createCustomer']['customer']['firstname']);
         $this->assertEquals($newLastname, $response['createCustomer']['customer']['lastname']);
         $this->assertEquals($newEmail, $response['createCustomer']['customer']['email']);

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GetAddressesTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GetAddressesTest.php
@@ -62,7 +62,7 @@ class GetAddressesTest extends GraphQlAbstract
             is_array([$response['customer']['addresses']]),
             " Addresses field must be of an array type."
         );
-        self::assertEquals($customer->getId(), $response['customer']['id']);
+        self::assertEquals(null, $response['customer']['id']);
         $this->assertCustomerAddressesFields($customer, $response);
     }
 
@@ -105,7 +105,7 @@ class GetAddressesTest extends GraphQlAbstract
      * @param CustomerInterface $customer
      * @param array $actualResponse
      */
-    public function assertCustomerAddressesFields($customer, $actualResponse)
+    private function assertCustomerAddressesFields($customer, $actualResponse)
     {
         /** @var AddressInterface $addresses */
         $addresses = $customer->getAddresses();
@@ -113,7 +113,7 @@ class GetAddressesTest extends GraphQlAbstract
             $this->assertNotEmpty($addressValue);
             $assertionMap = [
                 ['response_field' => 'id', 'expected_value' => $addresses[$addressKey]->getId()],
-                ['response_field' => 'customer_id', 'expected_value' => $addresses[$addressKey]->getCustomerId()],
+                ['response_field' => 'customer_id', 'expected_value' => 0],
                 ['response_field' => 'region_id', 'expected_value' => $addresses[$addressKey]->getRegionId()],
                 ['response_field' => 'country_id', 'expected_value' => $addresses[$addressKey]->getCountryId()],
                 ['response_field' => 'telephone', 'expected_value' => $addresses[$addressKey]->getTelephone()],

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GetCustomerTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GetCustomerTest.php
@@ -50,6 +50,7 @@ class GetCustomerTest extends GraphQlAbstract
         $query = <<<QUERY
 query {
     customer {
+        id
         firstname
         lastname
         email
@@ -58,6 +59,7 @@ query {
 QUERY;
         $response = $this->graphQlQuery($query, [], '', $this->getCustomerAuthHeaders($currentEmail, $currentPassword));
 
+        $this->assertEquals(null, $response['customer']['id']);
         $this->assertEquals('John', $response['customer']['firstname']);
         $this->assertEquals('Smith', $response['customer']['lastname']);
         $this->assertEquals($currentEmail, $response['customer']['email']);

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerAddressTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerAddressTest.php
@@ -59,7 +59,6 @@ class UpdateCustomerAddressTest extends GraphQlAbstract
     {
         $userName = 'customer@example.com';
         $password = 'password';
-        $customerId = 1;
         $addressId = 1;
 
         $mutation = $this->getMutation($addressId);
@@ -67,7 +66,7 @@ class UpdateCustomerAddressTest extends GraphQlAbstract
         $response = $this->graphQlMutation($mutation, [], '', $this->getCustomerAuthHeaders($userName, $password));
         $this->assertArrayHasKey('updateCustomerAddress', $response);
         $this->assertArrayHasKey('customer_id', $response['updateCustomerAddress']);
-        $this->assertEquals($customerId, $response['updateCustomerAddress']['customer_id']);
+        $this->assertEquals(null, $response['updateCustomerAddress']['customer_id']);
         $this->assertArrayHasKey('id', $response['updateCustomerAddress']);
 
         $address = $this->addressRepository->getById($addressId);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/graphql-ce/issues/907

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
