### PR TITLE
[BUGFIX] Return the url from the customUrlLocator when it is an array

### DIFF
--- a/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/EntityUrl.php
+++ b/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/EntityUrl.php
@@ -63,6 +63,9 @@ class EntityUrl implements ResolverInterface
             $url = ltrim($url, '/');
         }
         $customUrl = $this->customUrlLocator->locateUrl($url);
+        if (is_array($customUrl)) {
+            return $customUrl;
+        }
         $url = $customUrl ?: $url;
         $urlRewrite = $this->findCanonicalUrl($url, (int)$context->getExtensionAttributes()->getStore()->getId());
         if ($urlRewrite) {


### PR DESCRIPTION
 - for example wehn you have a module which has a Router to the routerList it doesn't have url_rewrites but with the urlLocators it is possible to also route these url_keys

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
I want to implement the customUrlLocator functionality for Mage2gen. I have taken a look at several blog modules and these even't implemented url_rewrites but a custom router.
https://github.com/krukas/Mage2Gen/pull/305

In the attachment there is an example module which has implemented the customUrlLocator.
[Mage2gen_BlogGraphQl.zip](https://github.com/magento/graphql-ce/files/3623589/Mage2gen_BlogGraphQl.zip)

![image](https://user-images.githubusercontent.com/6040343/65082490-5d9ed680-d9a6-11e9-90e5-440531ad306e.png)

![image](https://user-images.githubusercontent.com/6040343/65082495-62fc2100-d9a6-11e9-9d64-e5fe22224d49.png)

![image](https://user-images.githubusercontent.com/6040343/65082565-90e16580-d9a6-11e9-8014-410cd484bcf8.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)

