### PR TITLE
Add Merge Cart Mutation

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Cart/GetCart.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/GetCart.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\QuoteGraphQl\Model\Cart;
+
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\MaskedQuoteIdToQuoteIdInterface;
+use Magento\Quote\Model\Quote;
+
+/**
+ * Get cart merge
+ */
+class GetCart
+{
+    /**
+     * @var MaskedQuoteIdToQuoteIdInterface
+     */
+    private $maskedQuoteIdToQuoteId;
+
+    /**
+     * @var CartRepositoryInterface
+     */
+    private $cartRepository;
+
+    /**
+     * @param MaskedQuoteIdToQuoteIdInterface $maskedQuoteIdToQuoteId
+     * @param CartRepositoryInterface $cartRepository
+     */
+    public function __construct(
+        MaskedQuoteIdToQuoteIdInterface $maskedQuoteIdToQuoteId,
+        CartRepositoryInterface $cartRepository
+    ) {
+        $this->maskedQuoteIdToQuoteId = $maskedQuoteIdToQuoteId;
+        $this->cartRepository = $cartRepository;
+    }
+
+    /**
+     * Get cart for merge
+     *
+     * @param string $cartHash
+     * @param int|null $customerId
+     * @param int $storeId
+     * @return Quote
+     * @throws GraphQlNoSuchEntityException
+     * @throws NoSuchEntityException
+     */
+    public function execute(string $cartHash, ?int $customerId, int $storeId): Quote
+    {
+        try {
+            $cartId = $this->maskedQuoteIdToQuoteId->execute($cartHash);
+        } catch (NoSuchEntityException $exception) {
+            throw new GraphQlNoSuchEntityException(
+                __('Could not find a cart with ID "%masked_cart_id"', ['masked_cart_id' => $cartHash])
+            );
+        }
+
+        try {
+            /** @var Quote $cart */
+            $cart = $this->cartRepository->get($cartId);
+        } catch (NoSuchEntityException $e) {
+            throw new GraphQlNoSuchEntityException(
+                __('Could not find a cart with ID "%masked_cart_id"', ['masked_cart_id' => $cartHash])
+            );
+        }
+
+        if ((int)$cart->getStoreId() !== $storeId) {
+            throw new GraphQlNoSuchEntityException(
+                __(
+                    'Wrong store code specified for cart "%masked_cart_id"',
+                    ['masked_cart_id' => $cartHash]
+                )
+            );
+        }
+
+        $cartCustomerId = (int)$cart->getCustomerId();
+
+        /* Guest cart, allow operations */
+        if (0 === $cartCustomerId) {
+            return $cart;
+        }
+
+        if ($cartCustomerId !== $customerId) {
+            throw new GraphQlNoSuchEntityException(
+                __('The current user cannot perform operations on cart "%masked_cart_id"', ['masked_cart_id' => $cartHash])
+            );
+        }
+        return $cart;
+    }
+}

--- a/app/code/Magento/QuoteGraphQl/Model/Cart/MergeCarts.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/MergeCarts.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\QuoteGraphQl\Model\Cart;
+
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\QuoteIdMask;
+use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\ResourceModel\Quote\QuoteIdMask as QuoteIdMaskResourceModel;
+use Magento\Quote\Api\CartRepositoryInterface;
+
+/**
+ * Merge two carts
+ */
+class MergeCarts
+{
+    /**
+     * @var QuoteIdMaskFactory
+     */
+    private $quoteMaskFactory;
+
+    /**
+     * @var QuoteIdMaskResourceModel
+     */
+    private $quoteMaskResource;
+
+    /**
+     * @var CartRepositoryInterface
+     */
+    private $cartRepository;
+
+    /**
+     * @param QuoteIdMaskFactory $quoteMaskFactory
+     * @param QuoteIdMaskResourceModel $quoteMaskResource
+     * @param CartRepositoryInterface $cartRepository
+     */
+    public function __construct(
+        QuoteIdMaskFactory $quoteMaskFactory,
+        QuoteIdMaskResourceModel $quoteMaskResource,
+        CartRepositoryInterface $cartRepository
+    ) {
+        $this->quoteMaskFactory = $quoteMaskFactory;
+        $this->quoteMaskResource = $quoteMaskResource;
+        $this->cartRepository = $cartRepository;
+    }
+
+    /**
+     * Merge two quotes
+     *
+     * @param Quote $firstCart
+     * @param Quote $secondQuote
+     * @return string
+     */
+    public function execute(Quote $firstCart, Quote $secondQuote): string
+    {
+        $firstCart->merge($secondQuote);
+        $firstCart->setIsActive(true);
+
+        $this->updateMaskedId($secondQuote);
+        $maskedQuoteId = $this->updateMaskedId($firstCart);
+
+        $this->cartRepository->save($firstCart);
+
+        $secondQuote->setIsActive(false);
+        $this->cartRepository->save($secondQuote);
+
+        return $maskedQuoteId;
+    }
+
+    /**
+     * Update quote masked id
+     *
+     * @param Quote $quote
+     * @return string
+     */
+    private function updateMaskedId(Quote $quote): string
+    {
+        /** @var QuoteIdMask $quoteIdMask */
+        $quoteIdMask = $this->quoteMaskFactory->create();
+        $this->quoteMaskResource->load($quoteIdMask, $quote->getId(), 'quote_id');
+        $quoteIdMask->unsetData('masked_id');
+        $this->quoteMaskResource->save($quoteIdMask);
+        $maskedId = $quoteIdMask->getMaskedId();
+
+        return $maskedId;
+    }
+}

--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/MergeCarts.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/MergeCarts.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\QuoteGraphQl\Model\Resolver;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\QuoteGraphQl\Model\Cart\GetCart;
+use Magento\QuoteGraphQl\Model\Cart\MergeCarts as MergeCartsModel;
+
+/**
+ * @inheritdoc
+ */
+class MergeCarts implements ResolverInterface
+{
+    /**
+     * @var GetCart
+     */
+    private $getCart;
+
+    /**
+     * @var MergeCartsModel
+     */
+    private $mergeCarts;
+
+    /**
+     * @param GetCart $getCart
+     * @param MergeCartsModel $mergeCarts
+     */
+    public function __construct(
+        GetCart $getCart,
+        MergeCartsModel $mergeCarts
+    ) {
+        $this->getCart = $getCart;
+        $this->mergeCarts = $mergeCarts;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (empty($args['input']['first_cart_id'])) {
+            throw new GraphQlInputException(__('Required parameter "first_cart_id" is missing'));
+        }
+        if (empty($args['input']['second_cart_id'])) {
+            throw new GraphQlInputException(__('Required parameter "second_cart_id" is missing'));
+        }
+
+        $currentUserId = $context->getUserId();
+        $storeId = $storeId = (int) $context->getExtensionAttributes()->getStore()->getId();
+        $firstCart = $this->getCart->execute($args['input']['first_cart_id'], $currentUserId, $storeId);
+        $secondCart = $this->getCart->execute($args['input']['second_cart_id'], $currentUserId, $storeId);
+
+        $maskedQuoteId = $this->mergeCarts->execute($firstCart, $secondCart);
+
+        return $maskedQuoteId;
+    }
+}

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -20,6 +20,7 @@ type Mutation {
     setGuestEmailOnCart(input: SetGuestEmailOnCartInput): SetGuestEmailOnCartOutput @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\SetGuestEmailOnCart")
     setPaymentMethodAndPlaceOrder(input: SetPaymentMethodAndPlaceOrderInput): PlaceOrderOutput @deprecated(reason: "Should use setPaymentMethodOnCart and placeOrder mutations in single request.") @resolver(class: "\\Magento\\QuoteGraphQl\\Model\\Resolver\\SetPaymentAndPlaceOrder")
     placeOrder(input: PlaceOrderInput): PlaceOrderOutput @resolver(class: "\\Magento\\QuoteGraphQl\\Model\\Resolver\\PlaceOrder")
+    mergeCarts(input: MergeCartsInput): String @resolver(class: "\\Magento\\QuoteGraphQl\\Model\\Resolver\\MergeCarts")
 }
 
 input createEmptyCartInput {
@@ -144,6 +145,11 @@ input PaymentMethodInput {
 input SetGuestEmailOnCartInput {
     cart_id: String!
     email: String!
+}
+
+input MergeCartsInput {
+    first_cart_id: String!
+    second_cart_id: String!
 }
 
 type CartPrices {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/MergeCartsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/MergeCartsTest.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Quote\Customer;
+
+use Magento\Quote\Model\QuoteFactory;
+use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
+use Magento\Quote\Model\ResourceModel\Quote as QuoteResource;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+use Magento\Integration\Api\CustomerTokenServiceInterface;
+
+/**
+ * Test for merging customer carts
+ */
+class MergeCartsTest extends GraphQlAbstract
+{
+    /**
+     * @var QuoteResource
+     */
+    private $quoteResource;
+
+    /**
+     * @var QuoteFactory
+     */
+    private $quoteFactory;
+
+    /**
+     * @var QuoteIdToMaskedQuoteIdInterface
+     */
+    private $quoteIdToMaskedId;
+
+    /**
+     * @var CustomerTokenServiceInterface
+     */
+    private $customerTokenService;
+
+    protected function setUp()
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->quoteResource = $objectManager->get(QuoteResource::class);
+        $this->quoteFactory = $objectManager->get(QuoteFactory::class);
+        $this->quoteIdToMaskedId = $objectManager->get(QuoteIdToMaskedQuoteIdInterface::class);
+        $this->customerTokenService = $objectManager->get(CustomerTokenServiceInterface::class);
+    }
+
+    protected function tearDown()
+    {
+        $quote = $this->quoteFactory->create();
+        $this->quoteResource->load($quote, '1', 'customer_id');
+        $this->quoteResource->delete($quote);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Checkout/_files/quote_with_virtual_product_saved.php
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     */
+    public function testMergeGuestWithCustomerCart()
+    {
+        $firstQuote = $this->quoteFactory->create();
+        $this->quoteResource->load($firstQuote, 'test_quote', 'reserved_order_id');
+
+        $secondQuote = $this->quoteFactory->create();
+        $this->quoteResource->load($secondQuote, 'test_order_with_virtual_product_without_address', 'reserved_order_id');
+
+        $firstMaskedId = $this->quoteIdToMaskedId->execute((int)$firstQuote->getId());
+        $secondMaskedId = $this->quoteIdToMaskedId->execute((int)$secondQuote->getId());
+
+        $query = $this->getCartMergeMutation($firstMaskedId, $secondMaskedId);
+        $mergeResponse = $this->graphQlMutation($query, [], '', $this->getHeaderMap());
+
+        self::assertArrayHasKey('mergeCarts', $mergeResponse);
+        $maskedQuoteId = $mergeResponse['mergeCarts'];
+        self::assertNotEquals($firstMaskedId, $maskedQuoteId);
+        self::assertNotEquals($secondMaskedId, $maskedQuoteId);
+
+        $cartResponse = $this->graphQlMutation($this->getCartQuery($maskedQuoteId), [], '', $this->getHeaderMap());
+
+        self::assertArrayHasKey('cart', $cartResponse);
+        self::assertArrayHasKey('items', $cartResponse['cart']);
+        self::assertCount(2, $cartResponse['cart']['items']);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/make_cart_inactive.php
+     */
+    public function testMergeTwoCustomerCarts()
+    {
+        $firstQuote = $this->quoteFactory->create();
+        $this->quoteResource->load($firstQuote, 'test_quote', 'reserved_order_id');
+        $firstMaskedId = $this->quoteIdToMaskedId->execute((int)$firstQuote->getId());
+
+        $createCartResponse = $this->graphQlMutation($this->getCreateEmptyCartMutation(), [], '', $this->getHeaderMap());
+        self::assertArrayHasKey('createEmptyCart', $createCartResponse);
+        $secondMaskedId = $createCartResponse['createEmptyCart'];
+        $this->addSimpleProductToCart($secondMaskedId, $this->getHeaderMap());
+
+        $query = $this->getCartMergeMutation($firstMaskedId, $secondMaskedId);
+        $mergeResponse = $this->graphQlMutation($query, [], '', $this->getHeaderMap());
+
+        self::assertArrayHasKey('mergeCarts', $mergeResponse);
+        $maskedQuoteId = $mergeResponse['mergeCarts'];
+        self::assertNotEquals($firstMaskedId, $maskedQuoteId);
+        self::assertNotEquals($secondMaskedId, $maskedQuoteId);
+
+        $cartResponse = $this->graphQlMutation($this->getCartQuery($maskedQuoteId), [], '', $this->getHeaderMap());
+
+        self::assertArrayHasKey('cart', $cartResponse);
+        self::assertArrayHasKey('items', $cartResponse['cart']);
+        self::assertCount(1, $cartResponse['cart']['items']);
+
+        $item = $cartResponse['cart']['items'][0];
+        self::assertArrayHasKey('quantity', $item);
+        self::assertArrayHasKey('product', $item);
+        self::assertArrayHasKey('sku', $item['product']);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/two_customers.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     * @expectedException \Exception
+     * @expectedExceptionMessage The current user cannot perform operations on cart
+     */
+    public function testMergeOtherCustomerCart()
+    {
+        $firstQuote = $this->quoteFactory->create();
+        $this->quoteResource->load($firstQuote, 'test_quote', 'reserved_order_id');
+
+        $firstMaskedId = $this->quoteIdToMaskedId->execute((int)$firstQuote->getId());
+        $createCartResponse = $this->graphQlMutation($this->getCreateEmptyCartMutation(), [], '', $this->getHeaderMap('customer_two@example.com'));
+        self::assertArrayHasKey('createEmptyCart', $createCartResponse);
+        $secondMaskedId = $createCartResponse['createEmptyCart'];
+        $this->addSimpleProductToCart($secondMaskedId, $this->getHeaderMap('customer_two@example.com'));
+
+        $query = $this->getCartMergeMutation($firstMaskedId, $secondMaskedId);
+        $this->graphQlMutation($query, [], '', $this->getHeaderMap());
+    }
+
+    /**
+     * Add simple product to cart
+     *
+     * @param string $maskedId
+     * @param array $headerMap
+     */
+    private function addSimpleProductToCart(string $maskedId, array $headerMap): void
+    {
+        $result = $this->graphQlMutation($this->getAddProductToCartMutation($maskedId), [], '', $headerMap);
+        self::assertArrayHasKey('addSimpleProductsToCart', $result);
+        self::assertArrayHasKey('cart', $result['addSimpleProductsToCart']);
+        self::assertArrayHasKey('items', $result['addSimpleProductsToCart']['cart']);
+        self::assertArrayHasKey(0, $result['addSimpleProductsToCart']['cart']['items']);
+        self::assertArrayHasKey('quantity', $result['addSimpleProductsToCart']['cart']['items'][0]);
+        self::assertEquals(1, $result['addSimpleProductsToCart']['cart']['items'][0]['quantity']);
+        self::assertArrayHasKey('product', $result['addSimpleProductsToCart']['cart']['items'][0]);
+        self::assertArrayHasKey('sku', $result['addSimpleProductsToCart']['cart']['items'][0]['product']);
+        self::assertEquals('simple_product', $result['addSimpleProductsToCart']['cart']['items'][0]['product']['sku']);
+    }
+
+    /**
+     * Create the mergeCart mutation
+     *
+     * @param string $firstMaskedId
+     * @param string $secondMaskedId
+     * @return string
+     */
+    private function getCartMergeMutation(string $firstMaskedId, string $secondMaskedId): string
+    {
+        return <<<QUERY
+mutation {
+  mergeCarts(input: {
+    first_cart_id: "{$firstMaskedId}"
+    second_cart_id: "{$secondMaskedId}"
+  })
+}
+QUERY;
+    }
+
+    /**
+     * Get cart query
+     *
+     * @param string $maskedId
+     * @return string
+     */
+    private function getCartQuery(string $maskedId): string
+    {
+        return <<<QUERY
+{
+  cart(cart_id: "{$maskedId}") {
+    items {
+      quantity
+      product {
+        sku
+      }
+    }
+  }
+}
+QUERY;
+    }
+
+    /**
+     * Get create empty cart mutation
+     *
+     * @return string
+     */
+    private function getCreateEmptyCartMutation(): string
+    {
+        return <<<QUERY
+mutation {
+  createEmptyCart
+}
+QUERY;
+    }
+
+    /**
+     * Get add product to cart mutation
+     *
+     * @param string $maskedId
+     * @return string
+     */
+    private function getAddProductToCartMutation(string $maskedId): string
+    {
+        return <<<QUERY
+mutation {
+  addSimpleProductsToCart(input: {
+    cart_id: "{$maskedId}"
+    cart_items: {
+      data: {
+        quantity: 1
+        sku: "simple_product"
+      }
+    }
+  }) {
+    cart {
+      items {
+        quantity
+        product {
+          sku
+        }
+      }
+    }
+  }
+}
+QUERY;
+    }
+
+    /**
+     * @param string $username
+     * @param string $password
+     * @return array
+     * @throws \Magento\Framework\Exception\AuthenticationException
+     */
+    private function getHeaderMap(string $username = 'customer@example.com', string $password = 'password'): array
+    {
+        $customerToken = $this->customerTokenService->createCustomerAccessToken($username, $password);
+        $headerMap = ['Authorization' => 'Bearer ' . $customerToken];
+        return $headerMap;
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/MergeCartsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/MergeCartsTest.php
@@ -68,7 +68,11 @@ class MergeCartsTest extends GraphQlAbstract
         $this->quoteResource->load($firstQuote, 'test_quote', 'reserved_order_id');
 
         $secondQuote = $this->quoteFactory->create();
-        $this->quoteResource->load($secondQuote, 'test_order_with_virtual_product_without_address', 'reserved_order_id');
+        $this->quoteResource->load(
+            $secondQuote,
+            'test_order_with_virtual_product_without_address',
+            'reserved_order_id'
+        );
 
         $firstMaskedId = $this->quoteIdToMaskedId->execute((int)$firstQuote->getId());
         $secondMaskedId = $this->quoteIdToMaskedId->execute((int)$secondQuote->getId());
@@ -101,7 +105,12 @@ class MergeCartsTest extends GraphQlAbstract
         $this->quoteResource->load($firstQuote, 'test_quote', 'reserved_order_id');
         $firstMaskedId = $this->quoteIdToMaskedId->execute((int)$firstQuote->getId());
 
-        $createCartResponse = $this->graphQlMutation($this->getCreateEmptyCartMutation(), [], '', $this->getHeaderMap());
+        $createCartResponse = $this->graphQlMutation(
+            $this->getCreateEmptyCartMutation(),
+            [],
+            '',
+            $this->getHeaderMap()
+        );
         self::assertArrayHasKey('createEmptyCart', $createCartResponse);
         $secondMaskedId = $createCartResponse['createEmptyCart'];
         $this->addSimpleProductToCart($secondMaskedId, $this->getHeaderMap());
@@ -140,7 +149,12 @@ class MergeCartsTest extends GraphQlAbstract
         $this->quoteResource->load($firstQuote, 'test_quote', 'reserved_order_id');
 
         $firstMaskedId = $this->quoteIdToMaskedId->execute((int)$firstQuote->getId());
-        $createCartResponse = $this->graphQlMutation($this->getCreateEmptyCartMutation(), [], '', $this->getHeaderMap('customer_two@example.com'));
+        $createCartResponse = $this->graphQlMutation(
+            $this->getCreateEmptyCartMutation(),
+            [],
+            '',
+            $this->getHeaderMap('customer_two@example.com')
+        );
         self::assertArrayHasKey('createEmptyCart', $createCartResponse);
         $secondMaskedId = $createCartResponse['createEmptyCart'];
         $this->addSimpleProductToCart($secondMaskedId, $this->getHeaderMap('customer_two@example.com'));

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/MergeCartsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/MergeCartsTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Quote\Guest;
+
+use Magento\Quote\Model\QuoteFactory;
+use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
+use Magento\Quote\Model\ResourceModel\Quote as QuoteResource;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+/**
+ * Test for merging guest carts
+ */
+class MergeCartsTest extends GraphQlAbstract
+{
+    /**
+     * @var QuoteResource
+     */
+    private $quoteResource;
+
+    /**
+     * @var QuoteFactory
+     */
+    private $quoteFactory;
+
+    /**
+     * @var QuoteIdToMaskedQuoteIdInterface
+     */
+    private $quoteIdToMaskedId;
+
+    protected function setUp()
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->quoteResource = $objectManager->get(QuoteResource::class);
+        $this->quoteFactory = $objectManager->get(QuoteFactory::class);
+        $this->quoteIdToMaskedId = $objectManager->get(QuoteIdToMaskedQuoteIdInterface::class);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Checkout/_files/quote_with_simple_product_saved.php
+     * @magentoApiDataFixture Magento/Checkout/_files/quote_with_virtual_product_saved.php
+     */
+    public function testMergeGuestCarts()
+    {
+        $firstQuote = $this->quoteFactory->create();
+        $this->quoteResource->load($firstQuote, 'test_order_with_simple_product_without_address', 'reserved_order_id');
+
+        $secondQuote = $this->quoteFactory->create();
+        $this->quoteResource->load($secondQuote, 'test_order_with_virtual_product_without_address', 'reserved_order_id');
+
+        $firstMaskedId = $this->quoteIdToMaskedId->execute((int)$firstQuote->getId());
+        $secondMaskedId = $this->quoteIdToMaskedId->execute((int)$secondQuote->getId());
+
+        $query = $this->getCartMergeMutation($firstMaskedId, $secondMaskedId);
+        $mergeResponse = $this->graphQlMutation($query);
+
+        self::assertArrayHasKey('mergeCarts', $mergeResponse);
+        $maskedQuoteId = $mergeResponse['mergeCarts'];
+        self::assertNotEquals($firstMaskedId, $maskedQuoteId);
+        self::assertNotEquals($secondMaskedId, $maskedQuoteId);
+
+        $cartResponse = $this->graphQlMutation($this->getCartQuery($maskedQuoteId));
+
+        self::assertArrayHasKey('cart', $cartResponse);
+        self::assertArrayHasKey('items', $cartResponse['cart']);
+        self::assertCount(2, $cartResponse['cart']['items']);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Checkout/_files/quote_with_virtual_product_saved.php
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     * @expectedException \Exception
+     * @expectedExceptionMessage The current user cannot perform operations on cart
+     */
+    public function testMergeGuestWithCustomerCart()
+    {
+        $firstQuote = $this->quoteFactory->create();
+        $this->quoteResource->load($firstQuote, 'test_order_with_virtual_product_without_address', 'reserved_order_id');
+
+        $secondQuote = $this->quoteFactory->create();
+        $this->quoteResource->load($secondQuote, 'test_quote', 'reserved_order_id');
+
+        $firstMaskedId = $this->quoteIdToMaskedId->execute((int)$firstQuote->getId());
+        $secondMaskedId = $this->quoteIdToMaskedId->execute((int)$secondQuote->getId());
+
+        $query = $this->getCartMergeMutation($firstMaskedId, $secondMaskedId);
+        $this->graphQlMutation($query);
+    }
+
+    /**
+     * Create the mergeCart mutation
+     *
+     * @param string $firstMaskedId
+     * @param string $secondMaskedId
+     * @return string
+     */
+    private function getCartMergeMutation(string $firstMaskedId, string $secondMaskedId): string
+    {
+        return <<<QUERY
+mutation {
+  mergeCarts(input: {
+    first_cart_id: "{$firstMaskedId}"
+    second_cart_id: "{$secondMaskedId}"
+  })
+}
+QUERY;
+    }
+
+    /**
+     * Get cart query
+     *
+     * @param string $maskedId
+     * @return string
+     */
+    private function getCartQuery(string $maskedId): string
+    {
+        return <<<QUERY
+{
+  cart(cart_id: "{$maskedId}") {
+    items {
+      quantity
+      product {
+        sku
+      }
+    }
+  }
+}
+QUERY;
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/MergeCartsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/MergeCartsTest.php
@@ -51,7 +51,11 @@ class MergeCartsTest extends GraphQlAbstract
         $this->quoteResource->load($firstQuote, 'test_order_with_simple_product_without_address', 'reserved_order_id');
 
         $secondQuote = $this->quoteFactory->create();
-        $this->quoteResource->load($secondQuote, 'test_order_with_virtual_product_without_address', 'reserved_order_id');
+        $this->quoteResource->load(
+            $secondQuote,
+            'test_order_with_virtual_product_without_address',
+            'reserved_order_id'
+        );
 
         $firstMaskedId = $this->quoteIdToMaskedId->execute((int)$firstQuote->getId());
         $secondMaskedId = $this->quoteIdToMaskedId->execute((int)$secondQuote->getId());


### PR DESCRIPTION
### Description (*)

Add mutation for merging carts.

#### Guest Use Cases:
 * Merge two guest carts

#### Customer Use Cases:
 * Merge customer cart with guest cart
 * Merge customer cart with inactive customer cart

### Fixed Issues
1. magento/graphql-ce#905

### Manual testing scenarios (*)
1. Create two carts
2. Add products to each cart
3. 
```graphql
mutation {
  mergeCarts(input: {
    first_cart_id: "{$firstMaskedId}"
    second_cart_id: "{$secondMaskedId}"
  })
}
```

**Expected Result**
Cart contents are merged. A new masked cart id is returned and the previous masked ids return a not found error.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
