### PR TITLE
#878 - Deprecated the column increment_id

### DIFF
--- a/app/code/Magento/SalesGraphQl/Model/Resolver/Orders.php
+++ b/app/code/Magento/SalesGraphQl/Model/Resolver/Orders.php
@@ -56,6 +56,7 @@ class Orders implements ResolverInterface
             $items[] = [
                 'id' => $order->getId(),
                 'increment_id' => $order->getIncrementId(),
+                'order_number' => $order->getIncrementId(),
                 'created_at' => $order->getCreatedAt(),
                 'grand_total' => $order->getGrandTotal(),
                 'status' => $order->getStatus(),

--- a/app/code/Magento/SalesGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/SalesGraphQl/etc/schema.graphqls
@@ -7,7 +7,8 @@ type Query {
 
 type CustomerOrder @doc(description: "Order mapping fields") {
     id: Int
-    increment_id: String
+    increment_id: String @deprecated(reason: "Use the order_number instaed.")
+    order_number: String! @doc(description: "The order number")
     created_at: String
     grand_total: Float
     status: String

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Sales/OrdersTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Sales/OrdersTest.php
@@ -38,9 +38,7 @@ class OrdersTest extends GraphQlAbstract
 query {
   customerOrders {
     items {
-      id
-      increment_id
-      created_at
+      order_number
       grand_total
       status
     }
@@ -54,27 +52,27 @@ QUERY;
 
         $expectedData = [
             [
-                'increment_id' => '100000002',
+                'order_number' => '100000002',
                 'status' => 'processing',
                 'grand_total' => 120.00
             ],
             [
-                'increment_id' => '100000003',
+                'order_number' => '100000003',
                 'status' => 'processing',
                 'grand_total' => 130.00
             ],
             [
-                'increment_id' => '100000004',
+                'order_number' => '100000004',
                 'status' => 'closed',
                 'grand_total' => 140.00
             ],
             [
-                'increment_id' => '100000005',
+                'order_number' => '100000005',
                 'status' => 'complete',
                 'grand_total' => 150.00
             ],
             [
-                'increment_id' => '100000006',
+                'order_number' => '100000006',
                 'status' => 'complete',
                 'grand_total' => 160.00
             ]
@@ -84,9 +82,9 @@ QUERY;
 
         foreach ($expectedData as $key => $data) {
             $this->assertEquals(
-                $data['increment_id'],
-                $actualData[$key]['increment_id'],
-                "increment_id is different than the expected for order - " . $data['increment_id']
+                $data['order_number'],
+                $actualData[$key]['order_number'],
+                "order_number is different than the expected for order - " . $data['order_number']
             );
             $this->assertEquals(
                 $data['grand_total'],

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Sales/OrdersTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Sales/OrdersTest.php
@@ -89,12 +89,12 @@ QUERY;
             $this->assertEquals(
                 $data['grand_total'],
                 $actualData[$key]['grand_total'],
-                "grand_total is different than the expected for order - " . $data['increment_id']
+                "grand_total is different than the expected for order - " . $data['order_number']
             );
             $this->assertEquals(
                 $data['status'],
                 $actualData[$key]['status'],
-                "status is different than the expected for order - " . $data['increment_id']
+                "status is different than the expected for order - " . $data['order_number']
             );
         }
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
 - Added new column order_number with the type of String!
 - Changed the api_functional test in order to test a new field


### Fixed Issues 
1. magento/graphql-ce#878: [Checkout] Rename increment_id for CustomerOrder type

### Manual testing scenarios
See issue description

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
