### PR TITLE
Add Store Name to Config Schema

### DIFF
--- a/app/code/Magento/StoreGraphQl/etc/graphql/di.xml
+++ b/app/code/Magento/StoreGraphQl/etc/graphql/di.xml
@@ -23,4 +23,11 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\StoreGraphQl\Model\Resolver\Store\StoreConfigDataProvider">
+        <arguments>
+            <argument name="extendedConfigData" xsi:type="array">
+                <item name="store_name" xsi:type="string">store/information/name</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/StoreGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/StoreGraphQl/etc/schema.graphqls
@@ -30,4 +30,5 @@ type StoreConfig @doc(description: "The type contains information about a store 
     secure_base_link_url : String @doc(description: "Secure base link URL for the store")
     secure_base_static_url : String @doc(description: "Secure base static URL for the store")
     secure_base_media_url : String @doc(description: "Secure base media URL for the store")
+    store_name : String @doc(description: "Name of the store")
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Store/StoreConfigResolverTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Store/StoreConfigResolverTest.php
@@ -30,6 +30,7 @@ class StoreConfigResolverTest extends GraphQlAbstract
 
     /**
      * @magentoApiDataFixture Magento/Store/_files/store.php
+     * @magentoConfigFixture default_store store/information/name Test Store
      */
     public function testGetStoreConfig()
     {
@@ -62,7 +63,8 @@ class StoreConfigResolverTest extends GraphQlAbstract
     secure_base_url,
     secure_base_link_url,
     secure_base_static_url,
-    secure_base_media_url
+    secure_base_media_url,
+    store_name
   }
 }
 QUERY;
@@ -89,5 +91,6 @@ QUERY;
             $response['storeConfig']['secure_base_static_url']
         );
         $this->assertEquals($storeConfig->getSecureBaseMediaUrl(), $response['storeConfig']['secure_base_media_url']);
+        $this->assertEquals('Test Store', $response['storeConfig']['store_name']);
     }
 }


### PR DESCRIPTION
### Description (*)

Add store name to config schema

### Fixed Issues (if relevant)
1. magento/graphql-ce#926

### Manual testing scenarios (*)
1. Fetch store name with `storeConfig` query
```graphql
{
  storeConfig{
    store_name
  }
}
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
