### PR TITLE
#913 - Deprecated the gender column

### DIFF
--- a/app/code/Magento/CustomerGraphQl/Api/DataMapperInterface.php
+++ b/app/code/Magento/CustomerGraphQl/Api/DataMapperInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CustomerGraphQl\Api;
+
+/**
+ * Data mapper interface
+ */
+interface DataMapperInterface
+{
+    /**
+     * Execute the data mapping
+     * @param array $data
+     * @return array
+     */
+    public function execute(array $data): array;
+}

--- a/app/code/Magento/CustomerGraphQl/Model/Customer/DataMapper/DataMapperPool.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/DataMapper/DataMapperPool.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CustomerGraphQl\Model\Customer\DataMapper;
+
+use Magento\CustomerGraphQl\Api\DataMapperInterface;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+
+/**
+ * Data mapper pool, will perform the data mapping on customer response using the data mappers
+ */
+class DataMapperPool implements DataMapperInterface
+{
+    /**
+     * Data mappers
+     * @var array
+     */
+    private $dataMappers;
+
+    /**
+     * DataMapperPool constructor.
+     * @param array $dataMappers
+     */
+    public function __construct(array $dataMappers = [])
+    {
+        $this->dataMappers = $dataMappers;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(array $data): array
+    {
+        foreach ($this->dataMappers as $dataMapper) {
+            if (!$dataMapper instanceof DataMapperInterface) {
+                throw new GraphQlInputException(
+                    __('The data mapper does not implement %1', DataMapperInterface::class)
+                );
+            }
+
+            $data = $dataMapper->execute($data);
+        }
+
+        return $data;
+    }
+}

--- a/app/code/Magento/CustomerGraphQl/Model/Customer/DataMapper/FieldsDataMapper.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/DataMapper/FieldsDataMapper.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CustomerGraphQl\Model\Customer\DataMapper;
+
+use Magento\CustomerGraphQl\Api\DataMapperInterface;
+
+/**
+ * Data mapper pool, will perform the data mapping on customer response using the data mappers
+ */
+class FieldsDataMapper implements DataMapperInterface
+{
+    /**
+     * Fields mapping configuration
+     * @var array
+     */
+    private $fieldsMap;
+
+    /**
+     * Fields mapper initialization
+     * @param array $fieldsMap
+     */
+    public function __construct(array $fieldsMap = [])
+    {
+        $this->fieldsMap = $fieldsMap;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(array $data): array
+    {
+        foreach ($this->fieldsMap as $fieldName => $valuesMapConfig) {
+            if (isset($data[$fieldName])) {
+                $data[$valuesMapConfig['fieldName'] ?? $fieldName] = $valuesMapConfig['map'][$data[$fieldName]]
+                    ?? ($valuesMapConfig['defaultValue'] ?? $data[$fieldName]);
+            }
+        }
+
+        return $data;
+    }
+}

--- a/app/code/Magento/CustomerGraphQl/Model/Customer/ExtractCustomerData.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/ExtractCustomerData.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\CustomerGraphQl\Model\Customer;
 
 use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\CustomerGraphQl\Api\DataMapperInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\Webapi\ServiceOutputProcessor;
@@ -29,15 +30,24 @@ class ExtractCustomerData
     private $serializer;
 
     /**
+     * Data mapper instance
+     * @var DataMapperInterface
+     */
+    private $dataMapper;
+
+    /**
      * @param ServiceOutputProcessor $serviceOutputProcessor
      * @param SerializerInterface $serializer
+     * @param DataMapperInterface $dataMapper
      */
     public function __construct(
         ServiceOutputProcessor $serviceOutputProcessor,
-        SerializerInterface $serializer
+        SerializerInterface $serializer,
+        DataMapperInterface $dataMapper
     ) {
         $this->serviceOutputProcessor = $serviceOutputProcessor;
         $this->serializer = $serializer;
+        $this->dataMapper = $dataMapper;
     }
 
     /**
@@ -103,6 +113,6 @@ class ExtractCustomerData
         $customerData = array_merge($customerData, $customAttributes);
 
         $customerData['model'] = $customer;
-        return $customerData;
+        return $this->dataMapper->execute($customerData);
     }
 }

--- a/app/code/Magento/CustomerGraphQl/Model/Resolver/CreateCustomer.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Resolver/CreateCustomer.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\CustomerGraphQl\Model\Resolver;
 
+use Magento\CustomerGraphQl\Api\DataMapperInterface;
 use Magento\CustomerGraphQl\Model\Customer\CreateCustomerAccount;
 use Magento\CustomerGraphQl\Model\Customer\ExtractCustomerData;
 use Magento\Framework\GraphQl\Config\Element\Field;
@@ -37,20 +38,29 @@ class CreateCustomer implements ResolverInterface
     private $newsLetterConfig;
 
     /**
+     * Data mapper
+     * @var DataMapperInterface
+     */
+    private $dataMapper;
+
+    /**
      * CreateCustomer constructor.
      *
      * @param ExtractCustomerData $extractCustomerData
      * @param CreateCustomerAccount $createCustomerAccount
      * @param Config $newsLetterConfig
+     * @param DataMapperInterface $dataMapper
      */
     public function __construct(
         ExtractCustomerData $extractCustomerData,
         CreateCustomerAccount $createCustomerAccount,
-        Config $newsLetterConfig
+        Config $newsLetterConfig,
+        DataMapperInterface $dataMapper
     ) {
         $this->newsLetterConfig = $newsLetterConfig;
         $this->extractCustomerData = $extractCustomerData;
         $this->createCustomerAccount = $createCustomerAccount;
+        $this->dataMapper = $dataMapper;
     }
 
     /**
@@ -72,7 +82,7 @@ class CreateCustomer implements ResolverInterface
         }
       
         $customer = $this->createCustomerAccount->execute(
-            $args['input'],
+            $this->dataMapper->execute($args['input']),
             $context->getExtensionAttributes()->getStore()
         );
 

--- a/app/code/Magento/CustomerGraphQl/Model/Resolver/UpdateCustomer.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Resolver/UpdateCustomer.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\CustomerGraphQl\Model\Resolver;
 
+use Magento\CustomerGraphQl\Api\DataMapperInterface;
 use Magento\CustomerGraphQl\Model\Customer\GetCustomer;
 use Magento\CustomerGraphQl\Model\Customer\UpdateCustomerAccount;
 use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
@@ -38,18 +39,27 @@ class UpdateCustomer implements ResolverInterface
     private $extractCustomerData;
 
     /**
+     * Data mapper
+     * @var DataMapperInterface
+     */
+    private $dataMapper;
+
+    /**
      * @param GetCustomer $getCustomer
      * @param UpdateCustomerAccount $updateCustomerAccount
      * @param ExtractCustomerData $extractCustomerData
+     * @param DataMapperInterface $dataMapper
      */
     public function __construct(
         GetCustomer $getCustomer,
         UpdateCustomerAccount $updateCustomerAccount,
-        ExtractCustomerData $extractCustomerData
+        ExtractCustomerData $extractCustomerData,
+        DataMapperInterface $dataMapper
     ) {
         $this->getCustomer = $getCustomer;
         $this->updateCustomerAccount = $updateCustomerAccount;
         $this->extractCustomerData = $extractCustomerData;
+        $this->dataMapper = $dataMapper;
     }
 
     /**
@@ -74,7 +84,7 @@ class UpdateCustomer implements ResolverInterface
         $customer = $this->getCustomer->execute($context);
         $this->updateCustomerAccount->execute(
             $customer,
-            $args['input'],
+            $this->dataMapper->execute($args['input']),
             $context->getExtensionAttributes()->getStore()
         );
 

--- a/app/code/Magento/CustomerGraphQl/etc/graphql/di.xml
+++ b/app/code/Magento/CustomerGraphQl/etc/graphql/di.xml
@@ -20,4 +20,60 @@
             </argument>
         </arguments>
     </type>
+    <preference for="Magento\CustomerGraphQl\Api\DataMapperInterface" type="Magento\CustomerGraphQl\Model\Customer\DataMapper\DataMapperPool"/>
+    <virtualType name="CustomerGraphQlResolverCustomerFieldsMapper" type="Magento\CustomerGraphQl\Model\Customer\DataMapper\FieldsDataMapper">
+        <arguments>
+            <argument name="fieldsMap" xsi:type="array">
+                <item name="gender" xsi:type="array">
+                    <item name="fieldName" xsi:type="string">genderV2</item>
+                    <item name="map" xsi:type="array">
+                        <item name="1" xsi:type="string">MALE</item>
+                        <item name="2" xsi:type="string">FEMALE</item>
+                    </item>
+                </item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="CustomerGraphQlResolverCustomerDataMapperPool" type="Magento\CustomerGraphQl\Model\Customer\DataMapper\DataMapperPool">
+        <arguments>
+            <argument name="dataMappers" xsi:type="array">
+                <item name="fieldsMapper" xsi:type="object">CustomerGraphQlResolverCustomerFieldsMapper</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="CustomerGraphQlResolverCustomerMutationDataMapperPool" type="Magento\CustomerGraphQl\Model\Customer\DataMapper\DataMapperPool">
+        <arguments>
+            <argument name="dataMappers" xsi:type="array">
+                <item name="fieldsMapper" xsi:type="object">CustomerGraphQlResolverCustomerMutationFieldsMapper</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="CustomerGraphQlResolverCustomerMutationFieldsMapper" type="Magento\CustomerGraphQl\Model\Customer\DataMapper\FieldsDataMapper">
+        <arguments>
+            <argument name="fieldsMap" xsi:type="array">
+                <item name="genderV2" xsi:type="array">
+                    <item name="fieldName" xsi:type="string">gender</item>
+                    <item name="map" xsi:type="array">
+                        <item name="MALE" xsi:type="number">1</item>
+                        <item name="FEMALE" xsi:type="number">2</item>
+                    </item>
+                </item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <type name="Magento\CustomerGraphQl\Model\Customer\ExtractCustomerData">
+        <arguments>
+            <argument name="dataMapper" xsi:type="object">CustomerGraphQlResolverCustomerDataMapperPool</argument>
+        </arguments>
+    </type>
+    <type name="Magento\CustomerGraphQl\Model\Resolver\CreateCustomer">
+        <arguments>
+            <argument name="dataMapper" xsi:type="object">CustomerGraphQlResolverCustomerMutationDataMapperPool</argument>
+        </arguments>
+    </type>
+    <type name="Magento\CustomerGraphQl\Model\Resolver\UpdateCustomer">
+        <arguments>
+            <argument name="dataMapper" xsi:type="object">CustomerGraphQlResolverCustomerMutationDataMapperPool</argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
@@ -54,6 +54,11 @@ type CustomerToken {
     token: String @doc(description: "The customer token")
 }
 
+enum CustomerGenderEnum {
+    MALE @doc(description: "Male gender type, equivalent to 1 in magento")
+    FEMALE @doc(description: "Female gender type, equivalent to 2 in magento")
+}
+
 input CustomerInput {
     prefix: String @doc(description: "An honorific, such as Dr., Mr., or Mrs.")
     firstname: String @doc(description: "The customer's first name")
@@ -63,7 +68,8 @@ input CustomerInput {
     email: String @doc(description: "The customer's email address. Required")
     dob: String @doc(description: "The customer's date of birth")
     taxvat: String @doc(description: "The customer's Tax/VAT number (for corporate customers)")
-    gender: Int @doc(description: "The customer's gender(Male - 1, Female - 2)")
+    gender: Int @deprecated(reason: "Deprecated, use the genderV2 instead") @doc(description: "The customer's gender(Male - 1, Female - 2)")
+    genderV2: CustomerGenderEnum @doc(description: "The customer's gender")
     password: String @doc(description: "The customer's password")
     is_subscribed: Boolean @doc(description: "Indicates whether the customer is subscribed to the company's newsletter")
 }
@@ -92,7 +98,8 @@ type Customer @doc(description: "Customer defines the customer name and address 
     id: Int @doc(description: "The ID assigned to the customer")
     is_subscribed: Boolean @doc(description: "Indicates whether the customer is subscribed to the company's newsletter") @resolver(class: "\\Magento\\CustomerGraphQl\\Model\\Resolver\\IsSubscribed")
     addresses: [CustomerAddress] @doc(description: "An array containing the customer's shipping and billing addresses") @resolver(class: "\\Magento\\CustomerGraphQl\\Model\\Resolver\\CustomerAddresses")
-    gender: Int @doc(description: "The customer's gender(Male - 1, Female - 2)")
+    gender: Int @deprecated(reason: "Deprecated, use the genderV2 instead") @doc(description: "The customer's gender(Male - 1, Female - 2)")
+    genderV2: CustomerGenderEnum @doc(description: "The customer's gender")
 }
 
 type CustomerAddress @doc(description: "CustomerAddress contains detailed information about a customer's billing and shipping addresses"){

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CreateCustomerTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CreateCustomerTest.php
@@ -44,6 +44,7 @@ class CreateCustomerTest extends GraphQlAbstract
         $newLastname = 'Rowe';
         $currentPassword = 'test123#';
         $newEmail = 'new_customer@example.com';
+        $customerGender = 'MALE';
 
         $query = <<<QUERY
 mutation {
@@ -54,6 +55,7 @@ mutation {
             email: "{$newEmail}"
             password: "{$currentPassword}"
             is_subscribed: true
+            genderV2: {$customerGender}
         }
     ) {
         customer {
@@ -62,6 +64,7 @@ mutation {
             lastname
             email
             is_subscribed
+            genderV2
         }
     }
 }
@@ -72,6 +75,7 @@ QUERY;
         $this->assertEquals($newLastname, $response['createCustomer']['customer']['lastname']);
         $this->assertEquals($newEmail, $response['createCustomer']['customer']['email']);
         $this->assertEquals(true, $response['createCustomer']['customer']['is_subscribed']);
+        $this->assertEquals($customerGender, $response['createCustomer']['customer']['genderV2']);
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GetCustomerTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GetCustomerTest.php
@@ -46,6 +46,7 @@ class GetCustomerTest extends GraphQlAbstract
     {
         $currentEmail = 'customer@example.com';
         $currentPassword = 'password';
+        $customerGender = 'MALE';
 
         $query = <<<QUERY
 query {
@@ -53,6 +54,7 @@ query {
         firstname
         lastname
         email
+        genderV2
     }
 }
 QUERY;
@@ -61,6 +63,7 @@ QUERY;
         $this->assertEquals('John', $response['customer']['firstname']);
         $this->assertEquals('Smith', $response['customer']['lastname']);
         $this->assertEquals($currentEmail, $response['customer']['email']);
+        $this->assertEquals($customerGender, $response['customer']['genderV2']);
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GetCustomerTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GetCustomerTest.php
@@ -44,7 +44,7 @@ class GetCustomerTest extends GraphQlAbstract
      */
     public function testGetCustomer()
     {
-        $currentEmail = 'customer@example.com';
+        $currentEmail = 'customer_male@example.com';
         $currentPassword = 'password';
         $customerGender = 'MALE';
 

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerTest.php
@@ -47,7 +47,7 @@ class UpdateCustomerTest extends GraphQlAbstract
      */
     public function testUpdateCustomer()
     {
-        $currentEmail = 'customer@example.com';
+        $currentEmail = 'customer_male@example.com';
         $currentPassword = 'password';
 
         $newPrefix = 'Dr';

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerTest.php
@@ -57,7 +57,7 @@ class UpdateCustomerTest extends GraphQlAbstract
         $newSuffix = 'III';
         $newDob = '3/11/1972';
         $newTaxVat = 'GQL1234567';
-        $newGender = 2;
+        $newGender = 'FEMALE';
         $newEmail = 'customer_updated@example.com';
 
         $query = <<<QUERY
@@ -73,7 +73,7 @@ mutation {
             taxvat: "{$newTaxVat}"
             email: "{$newEmail}"
             password: "{$currentPassword}"
-            gender: {$newGender}
+            genderV2: {$newGender}
         }
     ) {
         customer {
@@ -85,7 +85,7 @@ mutation {
             dob
             taxvat
             email
-            gender
+            genderV2
         }
     }
 }
@@ -105,7 +105,7 @@ QUERY;
         $this->assertEquals($newDob, $response['updateCustomer']['customer']['dob']);
         $this->assertEquals($newTaxVat, $response['updateCustomer']['customer']['taxvat']);
         $this->assertEquals($newEmail, $response['updateCustomer']['customer']['email']);
-        $this->assertEquals($newGender, $response['updateCustomer']['customer']['gender']);
+        $this->assertEquals($newGender, $response['updateCustomer']['customer']['genderV2']);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Customer/_files/customer.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/_files/customer.php
@@ -27,8 +27,32 @@ $customer->setWebsiteId(1)
     ->setDefaultBilling(1)
     ->setDefaultShipping(1)
     ->setTaxvat('12')
+    ->setGender(0);
+
+$customer->isObjectNew(true);
+$customer->save();
+$customerRegistry->remove($customer->getId());
+
+$customer = $objectManager->create(\Magento\Customer\Model\Customer::class);
+/** @var Magento\Customer\Model\Customer $customer */
+$customer->setWebsiteId(1)
+    ->setId(2)
+    ->setEmail('customer_male@example.com')
+    ->setPassword('password')
+    ->setGroupId(1)
+    ->setStoreId(1)
+    ->setIsActive(1)
+    ->setPrefix('Mr.')
+    ->setFirstname('Veronica')
+    ->setMiddlename('A')
+    ->setLastname('Costello')
+    ->setSuffix('Esq.')
+    ->setDefaultBilling(1)
+    ->setDefaultShipping(1)
+    ->setTaxvat('12')
     ->setGender(1);
 
 $customer->isObjectNew(true);
 $customer->save();
 $customerRegistry->remove($customer->getId());
+

--- a/dev/tests/integration/testsuite/Magento/Customer/_files/customer.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/_files/customer.php
@@ -27,7 +27,7 @@ $customer->setWebsiteId(1)
     ->setDefaultBilling(1)
     ->setDefaultShipping(1)
     ->setTaxvat('12')
-    ->setGender(0);
+    ->setGender(1);
 
 $customer->isObjectNew(true);
 $customer->save();


### PR DESCRIPTION
### Description
 - Added new field genderV2 with the type of enum
 - Added data mapper in order to turn the gender value into genderV2 value and vice-versa
 - Extended api-functional tests

### Fixed Issues
1. magento/graphql-ce#913: [Customer] Convert gender type to enum

### Manual testing scenarios
See issue description

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
