### PR TITLE
[FEATURE] Added resolveRoute support (which is equal to Router for th…

### DIFF
--- a/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite/CustomRouteLocator.php
+++ b/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite/CustomRouteLocator.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\UrlRewriteGraphQl\Model\Resolver\UrlRewrite;
+
+/**
+ * Pool of custom route locators.
+ */
+class CustomRouteLocator implements CustomRouteLocatorInterface
+{
+    /**
+     * @var array
+     */
+    private $routeLocators;
+
+    /**
+     * @param CustomRouteLocatorInterface[] $routeLocators
+     */
+    public function __construct(
+        array $routeLocators = []
+    ) {
+        $this->routeLocators = $routeLocators;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolveRoute($urlKey): ?array
+    {
+        foreach ($this->routeLocators as $urlLocator) {
+            $url = $urlLocator->locateRoute($urlKey);
+            if ($url !== null) {
+                return $url;
+            }
+        }
+        return null;
+    }
+}

--- a/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite/CustomRouteLocatorInterface.php
+++ b/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite/CustomRouteLocatorInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\UrlRewriteGraphQl\Model\Resolver\UrlRewrite;
+
+/**
+ * Interface for resolution of custom routes.
+ *
+ * It can be used, for example, to resolve '/news' URL path to a 'Blog News' page.
+ */
+interface CustomRouteLocatorInterface
+{
+    /**
+     * Resolve route based on custom rules.
+     *
+     * @param string $urlKey
+     * @return array|null Return null if route cannot be resolved
+     */
+    public function resolveRoute($urlKey): ?array;
+}

--- a/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite/CustomUrlLocator.php
+++ b/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite/CustomUrlLocator.php
@@ -20,8 +20,9 @@ class CustomUrlLocator implements CustomUrlLocatorInterface
     /**
      * @param CustomUrlLocatorInterface[] $urlLocators
      */
-    public function __construct(array $urlLocators = [])
-    {
+    public function __construct(
+        array $urlLocators = []
+    ) {
         $this->urlLocators = $urlLocators;
     }
 

--- a/app/code/Magento/UrlRewriteGraphQl/etc/di.xml
+++ b/app/code/Magento/UrlRewriteGraphQl/etc/di.xml
@@ -7,4 +7,5 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Magento\UrlRewriteGraphQl\Model\Resolver\UrlRewrite\CustomUrlLocatorInterface" type="Magento\UrlRewriteGraphQl\Model\Resolver\UrlRewrite\CustomUrlLocator"/>
+    <preference for="Magento\UrlRewriteGraphQl\Model\Resolver\UrlRewrite\CustomRouteLocatorInterface" type="Magento\UrlRewriteGraphQl\Model\Resolver\UrlRewrite\CustomRouteLocator"/>
 </config>

--- a/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls
@@ -2,10 +2,10 @@
 # See COPYING.txt for license details.
 
 type Query {
-    urlResolver(url: String!): EntityUrl @resolver(class: "Magento\\UrlRewriteGraphQl\\Model\\Resolver\\EntityUrl") @doc(description: "The urlResolver query returns the relative URL for a specified product, category or CMS page, using as input a url_key appended by the url_suffix, if one exists") @cache(cacheIdentity: "Magento\\UrlRewriteGraphQl\\Model\\Resolver\\UrlRewrite\\UrlResolverIdentity")
+    urlResolver(url: String!): Url @resolver(class: "Magento\\UrlRewriteGraphQl\\Model\\Resolver\\Url") @doc(description: "The urlResolver query returns the relative URL for a specified product, category or CMS page, using as input a url_key appended by the url_suffix, if one exists") @cache(cacheIdentity: "Magento\\UrlRewriteGraphQl\\Model\\Resolver\\UrlRewrite\\UrlResolverIdentity")
 }
 
-type EntityUrl @doc(description: "EntityUrl is an output object containing the `id`, `relative_url`, and `type` attributes") {
+type Url @doc(description: "Url is an output object containing the `id`, `relative_url`, and `type` attributes") {
     id: Int @doc(description: "The ID assigned to the object associated with the specified url. This could be a product ID, category ID, or page ID.")
     canonical_url: String @deprecated(reason: "The canonical_url field is deprecated, use relative_url instead.")
     relative_url: String @doc(description: "The internal relative URL. If the specified  url is a redirect, the query returns the redirected URL, not the original.")


### PR DESCRIPTION
…e routerList implementation)

 - for example when you have a module which has a Router to the routerList it doesn't have url_rewrites but with the routeLocators it is possible to also route these url_keys

**This is a new PR according to
https://github.com/magento/graphql-ce/pull/939#issuecomment-533641652**

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
I want to implement the customUrlLocator functionality for Mage2gen. I have taken a look at several blog modules and these even't implemented url_rewrites but a custom router.
https://github.com/krukas/Mage2Gen/pull/305

In the attachment there is an example module which has implemented the customUrlLocator.
[Mage2gen_BlogGraphQl.zip](https://github.com/magento/graphql-ce/files/3623589/Mage2gen_BlogGraphQl.zip)

![image](https://user-images.githubusercontent.com/6040343/65082490-5d9ed680-d9a6-11e9-90e5-440531ad306e.png)

![image](https://user-images.githubusercontent.com/6040343/65082495-62fc2100-d9a6-11e9-9d64-e5fe22224d49.png)

![image](https://user-images.githubusercontent.com/6040343/65082565-90e16580-d9a6-11e9-8014-410cd484bcf8.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
