### PR TITLE
MAGETWO-24676: fixed adding variation from another configurable produ…

### DIFF
--- a/app/code/Magento/ConfigurableProductGraphQl/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
+++ b/app/code/Magento/ConfigurableProductGraphQl/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
@@ -79,7 +79,7 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
         }
         $configurableProductLinks = $parentProduct->getExtensionAttributes()->getConfigurableProductLinks();
         if (!in_array($product->getId(), $configurableProductLinks)) {
-            throw new GraphQlInputException(__('The child product do not belong to the parent product.'));
+            throw new GraphQlInputException(__('Could not find specified product.'));
         }
         $linkField = $this->metadataPool->getMetadata(ProductInterface::class)->getLinkField();
         $this->optionCollection->addProductId((int)$parentProduct->getData($linkField));

--- a/app/code/Magento/ConfigurableProductGraphQl/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
+++ b/app/code/Magento/ConfigurableProductGraphQl/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
@@ -9,6 +9,7 @@ namespace Magento\ConfigurableProductGraphQl\Model\Cart\BuyRequest;
 
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
 use Magento\Framework\Stdlib\ArrayManager;
 use Magento\QuoteGraphQl\Model\Cart\BuyRequest\BuyRequestDataProviderInterface;
@@ -75,6 +76,10 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
             $product = $this->productRepository->get($sku);
         } catch (NoSuchEntityException $e) {
             throw new GraphQlNoSuchEntityException(__('Could not find specified product.'));
+        }
+        $configurableProductLinks = $parentProduct->getExtensionAttributes()->getConfigurableProductLinks();
+        if (!in_array($product->getId(), $configurableProductLinks)) {
+            throw new GraphQlInputException(__('The child product do not belong to the parent product.'));
         }
         $linkField = $this->metadataPool->getMetadata(ProductInterface::class)->getLinkField();
         $this->optionCollection->addProductId((int)$parentProduct->getData($linkField));

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/AddConfigurableProductToCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/AddConfigurableProductToCartTest.php
@@ -145,7 +145,7 @@ QUERY;
      * @magentoApiDataFixture Magento/Checkout/_files/active_quote.php
      *
      * @expectedException Exception
-     * @expectedExceptionMessage The child product do not belong to the parent product.
+     * @expectedExceptionMessage Could not find specified product.
      */
     public function testAddVariationFromAnotherConfigurableProductWithTheSameSuperAttributeToCart()
     {
@@ -173,7 +173,7 @@ QUERY;
      * @magentoApiDataFixture Magento/Checkout/_files/active_quote.php
      *
      * @expectedException Exception
-     * @expectedExceptionMessage The child product do not belong to the parent product.
+     * @expectedExceptionMessage Could not find specified product.
      */
     public function testAddVariationFromAnotherConfigurableProductWithDifferentSuperAttributeToCart()
     {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/AddConfigurableProductToCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/AddConfigurableProductToCartTest.php
@@ -141,19 +141,14 @@ QUERY;
     }
 
     /**
-     * @magentoApiDataFixture Magento/ConfigurableProduct/_files/configurable_products.php
+     * @magentoApiDataFixture Magento/Catalog/_files/configurable_products_with_custom_attribute_layered_navigation.php
      * @magentoApiDataFixture Magento/Checkout/_files/active_quote.php
      *
      * @expectedException Exception
-     * @expectedExceptionMessage You need to choose options for your item.
+     * @expectedExceptionMessage The child product do not belong to the parent product.
      */
     public function testAddVariationFromAnotherConfigurableProductWithTheSameSuperAttributeToCart()
     {
-        $this->markTestSkipped(
-            'Magento automatically selects the correct child product according to the super attribute
-             https://github.com/magento/graphql-ce/issues/940'
-        );
-
         $searchResponse = $this->graphQlQuery($this->getFetchProductQuery('configurable_12345'));
         $product = current($searchResponse['products']['items']);
 
@@ -178,7 +173,7 @@ QUERY;
      * @magentoApiDataFixture Magento/Checkout/_files/active_quote.php
      *
      * @expectedException Exception
-     * @expectedExceptionMessage You need to choose options for your item.
+     * @expectedExceptionMessage The child product do not belong to the parent product.
      */
     public function testAddVariationFromAnotherConfigurableProductWithDifferentSuperAttributeToCart()
     {


### PR DESCRIPTION
…ct to cart if variation belongs to the same super attribute

### Description (*)
Implemented check whether a child product belongs to a parent product on add configurable product to cart action.

### Fixed Issues (if relevant)
1. magento/magento2#24676: Adding variation from another configurable product to cart if variation belongs to same super attribute is possible

### Manual testing scenarios (*)
See magento/magento2#24676