### PR TITLE
GraphQl-972: added support of the Global scope in the config fixture

### DIFF
--- a/dev/tests/api-functional/framework/Magento/TestFramework/Annotation/ApiConfigFixture.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/Annotation/ApiConfigFixture.php
@@ -10,6 +10,7 @@ namespace Magento\TestFramework\Annotation;
 use Magento\Config\Model\Config;
 use Magento\Config\Model\ResourceModel\Config as ConfigResource;
 use Magento\Config\Model\ResourceModel\Config\Data\CollectionFactory;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\TestCase;
@@ -155,5 +156,31 @@ class ApiConfigFixture extends ConfigFixture
         $storeManager = Bootstrap::getObjectManager()->get(StoreManagerInterface::class);
         $store = $storeManager->getStore($storeCode);
         return (int)$store->getId();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function _setConfigValue($configPath, $value, $storeCode = false)
+    {
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        if ($storeCode === false) {
+            $objectManager->get(
+                \Magento\TestFramework\App\ApiMutableScopeConfig::class
+            )->setValue(
+                $configPath,
+                $value,
+                ScopeConfigInterface::SCOPE_TYPE_DEFAULT
+            );
+        } else {
+            \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
+                \Magento\TestFramework\App\ApiMutableScopeConfig::class
+            )->setValue(
+                $configPath,
+                $value,
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                $storeCode
+            );
+        }
     }
 }

--- a/dev/tests/api-functional/framework/Magento/TestFramework/Annotation/ApiConfigFixture.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/Annotation/ApiConfigFixture.php
@@ -172,15 +172,16 @@ class ApiConfigFixture extends ConfigFixture
                 $value,
                 ScopeConfigInterface::SCOPE_TYPE_DEFAULT
             );
-        } else {
-            \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
-                \Magento\TestFramework\App\ApiMutableScopeConfig::class
-            )->setValue(
-                $configPath,
-                $value,
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                $storeCode
-            );
+
+            return;
         }
+        \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
+            \Magento\TestFramework\App\ApiMutableScopeConfig::class
+        )->setValue(
+            $configPath,
+            $value,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $storeCode
+        );
     }
 }

--- a/dev/tests/api-functional/framework/Magento/TestFramework/App/ApiMutableScopeConfig.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/App/ApiMutableScopeConfig.php
@@ -89,13 +89,12 @@ class ApiMutableScopeConfig implements MutableScopeConfigInterface
     {
         $pathParts = explode('/', $path);
         $store = 0;
-        if ($scopeType === \Magento\Store\Model\ScopeInterface::SCOPE_STORE) {
-            if ($scopeCode !== null) {
-                $store = ObjectManager::getInstance()
+        if ($scopeType === \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            && $scopeCode !== null) {
+            $store = ObjectManager::getInstance()
                     ->get(\Magento\Store\Api\StoreRepositoryInterface::class)
                     ->get($scopeCode)
                     ->getId();
-            }
         }
         $configData = [
             'section' => $pathParts[0],

--- a/dev/tests/api-functional/framework/Magento/TestFramework/App/ApiMutableScopeConfig.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/App/ApiMutableScopeConfig.php
@@ -17,7 +17,7 @@ use Magento\TestFramework\ObjectManager;
 /**
  * @inheritdoc
  */
-class MutableScopeConfig implements MutableScopeConfigInterface
+class ApiMutableScopeConfig implements MutableScopeConfigInterface
 {
     /**
      * @var Config
@@ -56,7 +56,6 @@ class MutableScopeConfig implements MutableScopeConfigInterface
     /**
      * Clean app config cache
      *
-     * @param string|null $type
      * @return void
      */
     public function clean()
@@ -89,17 +88,12 @@ class MutableScopeConfig implements MutableScopeConfigInterface
     private function persistConfig($path, $value, $scopeType, $scopeCode): void
     {
         $pathParts = explode('/', $path);
-        $store = '';
+        $store = 0;
         if ($scopeType === \Magento\Store\Model\ScopeInterface::SCOPE_STORE) {
             if ($scopeCode !== null) {
                 $store = ObjectManager::getInstance()
                     ->get(\Magento\Store\Api\StoreRepositoryInterface::class)
                     ->get($scopeCode)
-                    ->getId();
-            } else {
-                $store = ObjectManager::getInstance()
-                    ->get(\Magento\Store\Model\StoreManagerInterface::class)
-                    ->getStore()
                     ->getId();
             }
         }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/StoreConfigTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/StoreConfigTest.php
@@ -59,4 +59,50 @@ QUERY;
         $this->assertEquals('asc', $response['storeConfig']['catalog_default_sort_by']);
         $this->assertEquals(2, $response['storeConfig']['root_category_id']);
     }
+
+    /**
+     * @magentoApiDataFixture Magento/Store/_files/store.php
+     * @magentoConfigFixture catalog/seo/product_url_suffix global_test_product_suffix
+     * @magentoConfigFixture catalog/seo/category_url_suffix global_test_category_suffix
+     * @magentoConfigFixture catalog/seo/title_separator __
+     * @magentoConfigFixture catalog/frontend/list_mode 3
+     * @magentoConfigFixture catalog/frontend/grid_per_page_values 16
+     * @magentoConfigFixture catalog/frontend/list_per_page_values 8
+     * @magentoConfigFixture catalog/frontend/grid_per_page 16
+     * @magentoConfigFixture catalog/frontend/list_per_page 8
+     * @magentoConfigFixture catalog/frontend/default_sort_by asc
+     */
+    public function testGetStoreConfigGlobal()
+    {
+        $query
+            = <<<QUERY
+{
+  storeConfig{
+    product_url_suffix,
+    category_url_suffix,
+    title_separator,
+    list_mode,
+    grid_per_page_values,
+    list_per_page_values,
+    grid_per_page,
+    list_per_page,
+    catalog_default_sort_by,
+    root_category_id
+  }
+}
+QUERY;
+        $response = $this->graphQlQuery($query);
+        $this->assertArrayHasKey('storeConfig', $response);
+
+        $this->assertEquals('global_test_product_suffix', $response['storeConfig']['product_url_suffix']);
+        $this->assertEquals('global_test_category_suffix', $response['storeConfig']['category_url_suffix']);
+        $this->assertEquals('__', $response['storeConfig']['title_separator']);
+        $this->assertEquals('3', $response['storeConfig']['list_mode']);
+        $this->assertEquals('16', $response['storeConfig']['grid_per_page_values']);
+        $this->assertEquals(16, $response['storeConfig']['grid_per_page']);
+        $this->assertEquals('8', $response['storeConfig']['list_per_page_values']);
+        $this->assertEquals(8, $response['storeConfig']['list_per_page']);
+        $this->assertEquals('asc', $response['storeConfig']['catalog_default_sort_by']);
+        $this->assertEquals(2, $response['storeConfig']['root_category_id']);
+    }
 }


### PR DESCRIPTION
### Description (*)
This PR makes possible setting store configuration via magentoConfigFixture on the global level. E.g:
 ``` * @magentoConfigFixture catalog/seo/title_separator __ ```

### Fixed Issues (if relevant)
1. #972: @magentoConfigFixture does not work with the default scope

