### PR TITLE
GraphQl-963: Returns the content of CmsBlock as an object

### DIFF
--- a/app/code/Magento/CmsGraphQl/Model/Resolver/Content.php
+++ b/app/code/Magento/CmsGraphQl/Model/Resolver/Content.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CmsGraphQl\Model\Resolver;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+/**
+ * Extension point for CMS content to be in different, no HTML representation
+ */
+class Content implements ResolverInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ): array {
+        if (!isset($value['content'])) {
+            throw new LocalizedException(__('"content" value should be specified'));
+        }
+        return ['html' => $value['content']];
+    }
+}

--- a/app/code/Magento/CmsGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CmsGraphQl/etc/schema.graphqls
@@ -39,5 +39,6 @@ type CmsBlocks @doc(description: "CMS blocks information") {
 type CmsBlock @doc(description: "CMS block defines all CMS block information") {
     identifier: String @doc(description: "CMS block identifier")
     title: String @doc(description: "CMS block title")
-    content: String @doc(description: "CMS block content")
+    content: String @deprecated(reason: "CmsBlock content should be a ComplexTextValue to allow add CMS content in different, no HTML representation. Use the `block_content` instead.")
+    block_content: ComplexTextValue @doc(description: "CMS block content") @resolver(class: "\\Magento\\CmsGraphQl\\Model\\Resolver\\Content")
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Cms/CmsBlockTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Cms/CmsBlockTest.php
@@ -52,7 +52,9 @@ class CmsBlockTest extends GraphQlAbstract
     items {
       identifier
       title
-      content
+      block_content {
+        html
+      }
     }
   }
 }
@@ -64,7 +66,9 @@ QUERY;
 
         self::assertEquals($cmsBlockData['identifier'], $response['cmsBlocks']['items'][0]['identifier']);
         self::assertEquals($cmsBlockData['title'], $response['cmsBlocks']['items'][0]['title']);
-        self::assertEquals($renderedContent, $response['cmsBlocks']['items'][0]['content']);
+        self::assertArrayHasKey('block_content', $response['cmsBlocks']['items'][0]);
+        self::assertArrayHasKey('html', $response['cmsBlocks']['items'][0]['block_content']);
+        self::assertEquals($renderedContent, $response['cmsBlocks']['items'][0]['block_content']['html']);
     }
 
     /**
@@ -86,7 +90,9 @@ QUERY;
     items {
       identifier
       title
-      content
+      block_content {
+        html
+      }
     }
   }
 }
@@ -97,7 +103,9 @@ QUERY;
         self::assertArrayHasKey('items', $response['cmsBlocks']);
         self::assertEquals($cmsBlockData['identifier'], $response['cmsBlocks']['items'][0]['identifier']);
         self::assertEquals($cmsBlockData['title'], $response['cmsBlocks']['items'][0]['title']);
-        self::assertEquals($renderedContent, $response['cmsBlocks']['items'][0]['content']);
+        self::assertArrayHasKey('block_content', $response['cmsBlocks']['items'][0]);
+        self::assertArrayHasKey('html', $response['cmsBlocks']['items'][0]['block_content']);
+        self::assertEquals($renderedContent, $response['cmsBlocks']['items'][0]['block_content']['html']);
     }
 
     /**
@@ -117,7 +125,9 @@ QUERY;
     items {
       identifier
       title
-      content
+      block_content {
+        html
+      }
     }
   }
 }
@@ -140,7 +150,9 @@ QUERY;
     items {
       identifier
       title
-      content
+      block_content {
+        html
+      }
     }
   }
 }
@@ -163,7 +175,9 @@ QUERY;
     items {
       identifier
       title
-      content
+      block_content {
+        html
+      }
     }
   }
 }


### PR DESCRIPTION
### Description (*)
The implementation of CMS block content as an object.
The new `block_content` field is an extension point for adding other types of rendering:
```
{
  cmsBlocks(identifiers: "BLOCK_ID") {
    items {
      identifier
      title
      block_content {
        html
      }
    }
  }
}
```

### Fixed Issues (if relevant)
1. #963: [Cms] Make content field of CmsBlock an object

