### PR TITLE
#981 Extend test coverage for BraintreeGraphQl

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Braintree/CreateBraintreeClientTokenTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Braintree/CreateBraintreeClientTokenTest.php
@@ -20,6 +20,7 @@ class CreateBraintreeClientTokenTest extends GraphQlAbstract
      * @magentoConfigFixture default_store payment/braintree/active 1
      * @magentoConfigFixture default_store payment/braintree/environment sandbox
      * @magentoConfigFixture default_store payment/braintree/merchant_id def_merchant_id
+     * @magentoConfigFixture default_store payment/braintree/merchant_account_id def_merchant_id
      * @magentoConfigFixture default_store payment/braintree/public_key def_public_key
      * @magentoConfigFixture default_store payment/braintree/private_key def_private_key
      */

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Braintree/Customer/SetPaymentMethodTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Braintree/Customer/SetPaymentMethodTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\GraphQl\Braintree\Customer;
 
 use Magento\Braintree\Gateway\Command\GetPaymentNonceCommand;
+use Magento\Framework\Exception\AuthenticationException;
 use Magento\Framework\Registry;
 use Magento\GraphQl\Quote\GetMaskedQuoteIdByReservedOrderId;
 use Magento\Integration\Api\CustomerTokenServiceInterface;
@@ -261,6 +262,34 @@ class SetPaymentMethodTest extends GraphQlAbstract
         $this->graphQlMutation($setPaymentQuery, [], '', $this->getHeaderMap());
     }
 
+    /**
+     * @magentoConfigFixture default_store carriers/flatrate/active 1
+     * @magentoConfigFixture default_store payment/braintree/active 1
+     * @magentoConfigFixture default_store payment/braintree_cc_vault/active 1
+     * @magentoConfigFixture default_store payment/braintree/environment sandbox
+     * @magentoConfigFixture default_store payment/braintree/merchant_id def_merchant_id
+     * @magentoConfigFixture default_store payment/braintree/public_key def_public_key
+     * @magentoConfigFixture default_store payment/braintree/private_key def_private_key
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_shipping_address.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_billing_address.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_flatrate_shipping_method.php
+     * @dataProvider dataProviderTestSetPaymentMethodInvalidInput
+     * @expectedException \Exception
+     */
+    public function testSetPaymentMethodWithoutRequiredPaymentMethodInput()
+    {
+        $reservedOrderId = 'test_quote';
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute($reservedOrderId);
+
+        $setPaymentQuery = $this->getSetPaymentBraintreeQueryInvalidPaymentMethodInput($maskedQuoteId);
+        $this->expectExceptionMessage("for \"braintree\" is missing.");
+        $this->graphQlMutation($setPaymentQuery, [], '', $this->getHeaderMap());
+    }
+
     public function dataProviderTestSetPaymentMethodInvalidInput(): array
     {
         return [
@@ -373,6 +402,33 @@ QUERY;
 
     /**
      * @param string $maskedQuoteId
+     * @return string
+     */
+    private function getSetPaymentBraintreeQueryInvalidPaymentMethodInput(string $maskedQuoteId): string
+    {
+        return <<<QUERY
+mutation {
+  setPaymentMethodOnCart(input:{
+    cart_id:"{$maskedQuoteId}"
+    payment_method:{
+      code:"braintree"
+      braintree:{
+        payment_method_nonce:"fake-valid-nonce"
+      }
+    }
+  }) {
+    cart {
+      selected_payment_method {
+        code
+      }
+    }
+  }
+}
+QUERY;
+    }
+
+    /**
+     * @param string $maskedQuoteId
      * @param string $methodCode
      * @return string
      */
@@ -437,7 +493,7 @@ QUERY;
      * @param string $username
      * @param string $password
      * @return array
-     * @throws \Magento\Framework\Exception\AuthenticationException
+     * @throws AuthenticationException
      */
     private function getHeaderMap(string $username = 'customer@example.com', string $password = 'password'): array
     {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Cover exception: 
- `Required parameter "is_active_payment_token_enabler" for "braintree" is missing.`

Cover:
 - Case when Magento\Braintree\Gateway\Request\PaymentDataBuilder receives MERCHANT_ACCOUNT_ID (deprecated)

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/graphql-ce#981: [Test Coverage] Extend test coverage for BraintreeGraphQl

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. n/a

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
