### PR TITLE
magento graphql-ce#970  Cannot return several errors for one GraphQL request

### DIFF
--- a/lib/internal/Magento/Framework/GraphQl/Exception/GraphQlInputException.php
+++ b/lib/internal/Magento/Framework/GraphQl/Exception/GraphQlInputException.php
@@ -7,13 +7,15 @@ declare(strict_types=1);
 
 namespace Magento\Framework\GraphQl\Exception;
 
-use Magento\Framework\Exception\InputException;
+use Magento\Framework\Exception\AggregateExceptionInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
+use GraphQL\Error\ClientAware;
 
 /**
  * Exception for GraphQL to be thrown when user supplies invalid input
  */
-class GraphQlInputException extends InputException implements \GraphQL\Error\ClientAware
+class GraphQlInputException extends LocalizedException implements AggregateExceptionInterface, ClientAware
 {
     const EXCEPTION_CATEGORY = 'graphql-input';
 
@@ -21,6 +23,13 @@ class GraphQlInputException extends InputException implements \GraphQL\Error\Cli
      * @var boolean
      */
     private $isSafe;
+
+    /**
+     * The array of errors that have been added via the addError() method
+     *
+     * @var \Magento\Framework\Exception\LocalizedException[]
+     */
+    private $errors = [];
 
     /**
      * Initialize object
@@ -50,5 +59,23 @@ class GraphQlInputException extends InputException implements \GraphQL\Error\Cli
     public function getCategory() : string
     {
         return self::EXCEPTION_CATEGORY;
+    }
+
+    /**
+     * @param LocalizedException $exception
+     * @return $this
+     */
+    public function addError(LocalizedException $exception): self
+    {
+        $this->errors[] = $exception;
+        return $this;
+    }
+
+    /**
+     * @return LocalizedException[]
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
     }
 }

--- a/lib/internal/Magento/Framework/GraphQl/Exception/GraphQlInputException.php
+++ b/lib/internal/Magento/Framework/GraphQl/Exception/GraphQlInputException.php
@@ -62,6 +62,8 @@ class GraphQlInputException extends LocalizedException implements AggregateExcep
     }
 
     /**
+     * Add child error if used as aggregate exception
+     *
      * @param LocalizedException $exception
      * @return $this
      */
@@ -72,6 +74,8 @@ class GraphQlInputException extends LocalizedException implements AggregateExcep
     }
 
     /**
+     * Get child errors if used as aggregate exception
+     *
      * @return LocalizedException[]
      */
     public function getErrors(): array


### PR DESCRIPTION
- fixed magento/graphql-ce#970
- made it possible to use `addError` method of `GraphQlInputException`  in order to show multiple input validation error messages.

Example:
``` php
$e = new GraphQlInputException(__('Address validation error'));
/** @var \Magento\Framework\Phrase $error */
foreach ($errors as $error) {
    $e->addError(new GraphQlInputException(__($error)));
}
throw $e;
```
