### PR TITLE
[FEATURE] Added cache identity to the StoreConfig GraphQl API Endpoint

### DIFF
--- a/app/code/Magento/StoreGraphQl/Model/Resolver/Store/Identity.php
+++ b/app/code/Magento/StoreGraphQl/Model/Resolver/Store/Identity.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\StoreGraphQl\Model\Resolver\Store;
+
+use Magento\Framework\GraphQl\Query\Resolver\IdentityInterface;
+
+/**
+ * Class Identity
+ *
+ * @package Magento\StoreGraphQl\Model\Resolver\Store
+ */
+class Identity implements IdentityInterface
+{
+    /**
+     * @var string
+     */
+    private $cacheTag = \Magento\Framework\App\Config::CACHE_TAG;
+
+    /**
+     * @inheritDoc
+     */
+    public function getIdentities(array $resolvedData): array
+    {
+        $ids =  empty($resolvedData) ?
+            [] : array_merge([$this->cacheTag], array_map(function ($key) { return sprintf('%s_%s', $this->cacheTag, $key); }, array_keys($resolvedData)));
+        return $ids;
+    }
+}

--- a/app/code/Magento/StoreGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/StoreGraphQl/etc/schema.graphqls
@@ -1,7 +1,7 @@
 # Copyright © Magento, Inc. All rights reserved.
 # See COPYING.txt for license details.
 type Query {
-    storeConfig : StoreConfig @resolver(class: "Magento\\StoreGraphQl\\Model\\Resolver\\StoreConfigResolver") @doc(description: "The store config query") @cache(cacheable: false)
+    storeConfig : StoreConfig @resolver(class: "Magento\\StoreGraphQl\\Model\\Resolver\\StoreConfigResolver") @doc(description: "The store config query") @cache(cacheIdentity: "Magento\\StoreGraphQl\\Model\\Resolver\\Store\\Identity")
 }
 
 type Website @doc(description: "The type contains information about a website") {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
For performance reasons you want to cache the StoreConfig output because the output is the same for every request but the returned value is based on the request type.

So for example:

In the cache all the data is saved but when you request only base_currency_code it will still cache the full response but only return base_currency_code.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Enable FPC
2. Make an api get request for the storeConfig
3. First will be a cache MISS (see screenshot 1)
4. Try again
5. Now you will have a cache HIT (see screenshot 2)

Screenshot 1:
![image](https://user-images.githubusercontent.com/6040343/67205020-19707d00-f40f-11e9-9edf-601fe2138eca.png)

Screenshot 2:
![image](https://user-images.githubusercontent.com/6040343/67205024-1e353100-f40f-11e9-917e-48b351a79b0b.png)


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
