### PR TITLE
magento/graphql-ce#1009: [Test Coverage] Cover exception in SalesGraphQl\Model\Resolver\Orders

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Sales/OrdersTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Sales/OrdersTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\GraphQl\Sales;
 
+use Exception;
 use Magento\Integration\Api\CustomerTokenServiceInterface;
 use Magento\TestFramework\TestCase\GraphQlAbstract;
 use Magento\TestFramework\Helper\Bootstrap;
@@ -97,6 +98,25 @@ QUERY;
                 "status is different than the expected for order - " . $data['order_number']
             );
         }
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage The current customer isn't authorized.
+     */
+    public function testOrdersQueryNotAuthorized()
+    {
+        $query = <<<QUERY
+{
+  customerOrders {
+    items {
+      increment_id
+      grand_total
+    }
+  }
+}
+QUERY;
+        $this->graphQlQuery($query);
     }
 
     /**


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Pull request fixes https://github.com/magento/graphql-ce/issues/1009 `[Test Coverage] Cover exception in SalesGraphQl\Model\Resolver\Orders` issue.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#1009: [Test Coverage] Cover exception in SalesGraphQl\Model\Resolver\Orders

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)

Thank you!