### PR TITLE
#1029 Add Postcode as required depending of the country Mutation createCustomerAddress

### DIFF
--- a/app/code/Magento/CustomerGraphQl/Model/Customer/Address/CreateCustomerAddress.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/Address/CreateCustomerAddress.php
@@ -111,7 +111,7 @@ class CreateCustomerAddress
         $errorInput = [];
 
         //Add error for empty postcode with country with no optional ZIP
-        if (!in_array($addressData['country_id'], $this->directoryData->getCountriesWithOptionalZip())
+        if (!$this->directoryData->isZipCodeOptional($addressData['country_id'])
             && (!isset($addressData['postcode']) || empty($addressData['postcode']))
         ) {
             $errorInput[] = 'postcode';

--- a/app/code/Magento/CustomerGraphQl/Model/Customer/Address/CreateCustomerAddress.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/Address/CreateCustomerAddress.php
@@ -10,9 +10,10 @@ namespace Magento\CustomerGraphQl\Model\Customer\Address;
 use Magento\Customer\Api\AddressRepositoryInterface;
 use Magento\Customer\Api\Data\AddressInterface;
 use Magento\Customer\Api\Data\AddressInterfaceFactory;
+use Magento\Directory\Helper\Data as DirectoryData;
+use Magento\Framework\Api\DataObjectHelper;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
-use Magento\Framework\Api\DataObjectHelper;
 
 /**
  * Create customer address
@@ -38,23 +39,30 @@ class CreateCustomerAddress
      * @var DataObjectHelper
      */
     private $dataObjectHelper;
+    /**
+     * @var DirectoryData
+     */
+    private $directoryData;
 
     /**
      * @param GetAllowedAddressAttributes $getAllowedAddressAttributes
      * @param AddressInterfaceFactory $addressFactory
      * @param AddressRepositoryInterface $addressRepository
      * @param DataObjectHelper $dataObjectHelper
+     * @param DirectoryData $directoryData
      */
     public function __construct(
         GetAllowedAddressAttributes $getAllowedAddressAttributes,
         AddressInterfaceFactory $addressFactory,
         AddressRepositoryInterface $addressRepository,
-        DataObjectHelper $dataObjectHelper
+        DataObjectHelper $dataObjectHelper,
+        DirectoryData $directoryData
     ) {
         $this->getAllowedAddressAttributes = $getAllowedAddressAttributes;
         $this->addressFactory = $addressFactory;
         $this->addressRepository = $addressRepository;
         $this->dataObjectHelper = $dataObjectHelper;
+        $this->directoryData = $directoryData;
     }
 
     /**
@@ -101,6 +109,13 @@ class CreateCustomerAddress
     {
         $attributes = $this->getAllowedAddressAttributes->execute();
         $errorInput = [];
+
+        //Add error for empty postcode with country with no optional ZIP
+        if (!in_array($addressData['country_id'], $this->directoryData->getCountriesWithOptionalZip())
+            && (!isset($addressData['postcode']) || empty($addressData['postcode']))
+        ) {
+            $errorInput[] = 'postcode';
+        }
 
         foreach ($attributes as $attributeName => $attributeInfo) {
             if ($attributeInfo->getIsRequired()

--- a/app/code/Magento/CustomerGraphQl/composer.json
+++ b/app/code/Magento/CustomerGraphQl/composer.json
@@ -4,7 +4,6 @@
   "type": "magento2-module",
   "require": {
     "php": "~7.1.3||~7.2.0||~7.3.0",
-    "magento/module-customer": "*",
     "magento/module-authorization": "*",
     "magento/module-customer": "*",
     "magento/module-eav": "*",
@@ -12,7 +11,8 @@
     "magento/module-newsletter": "*",
     "magento/module-integration": "*",
     "magento/module-store": "*",
-    "magento/framework": "*"
+    "magento/framework": "*",
+    "magento/module-directory": "*"
   },
   "license": [
     "OSL-3.0",

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CreateCustomerAddressTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CreateCustomerAddressTest.php
@@ -359,6 +359,67 @@ MUTATION;
     }
 
     /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer_without_addresses.php
+     * @magentoConfigFixture default_store general/country/optional_zip_countries UA
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    public function testCreateCustomerAddressWithOptionalZipCode()
+    {
+        $newAddress = [
+            'country_code' => 'UA',
+            'street' => ['Line 1 Street', 'Line 2'],
+            'company' => 'Company name',
+            'telephone' => '123456789',
+            'fax' => '123123123',
+            'city' => 'City Name',
+            'firstname' => 'Adam',
+            'lastname' => 'Phillis',
+            'middlename' => 'A',
+            'prefix' => 'Mr.',
+            'suffix' => 'Jr.',
+            'vat_id' => '1',
+            'default_shipping' => true,
+            'default_billing' => false
+        ];
+
+        $mutation
+            = <<<MUTATION
+mutation {
+  createCustomerAddress(input: {
+    country_code: {$newAddress['country_code']}
+    street: ["{$newAddress['street'][0]}","{$newAddress['street'][1]}"]
+    company: "{$newAddress['company']}"
+    telephone: "{$newAddress['telephone']}"
+    fax: "{$newAddress['fax']}"
+    city: "{$newAddress['city']}"
+    firstname: "{$newAddress['firstname']}"
+    lastname: "{$newAddress['lastname']}"
+    middlename: "{$newAddress['middlename']}"
+    prefix: "{$newAddress['prefix']}"
+    suffix: "{$newAddress['suffix']}"
+    vat_id: "{$newAddress['vat_id']}"
+    default_shipping: true
+    default_billing: false
+  }) {
+    id
+  }
+}
+MUTATION;
+
+        $userName = 'customer@example.com';
+        $password = 'password';
+
+        $response = $this->graphQlMutation(
+            $mutation,
+            [],
+            '',
+            $this->getCustomerAuthHeaders($userName, $password)
+        );
+        $this->assertNotEmpty($response['createCustomerAddress']['id']);
+    }
+
+    /**
      * Create new address with invalid input
      *
      * @magentoApiDataFixture Magento/Customer/_files/customer_without_addresses.php


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Adding a validation with country and postcode to set is required for the mutation createCustomerAddress

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/graphql-ce#1029: Postcode is not listed in the array of errors

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Described in: magento/graphql-ce#1029

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [] All new or changed code is covered with unit/integration tests (if applicable)
 - [] All automated tests passed successfully (all builds are green)
