### PR TITLE
Throw InputException if 'country_code'-parameter is missing

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Cart/QuoteAddressFactory.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/QuoteAddressFactory.php
@@ -61,7 +61,12 @@ class QuoteAddressFactory
     public function createBasedOnInputData(array $addressInput): QuoteAddress
     {
         $addressInput['country_id'] = '';
-        if ($addressInput['country_code']) {
+        if (!isset($addressInput['country_code'])) {
+            throw new GraphQlInputException(
+                __('"Required parameter "country_code" is missing')
+            );
+        }
+        else {
             $addressInput['country_code'] = strtoupper($addressInput['country_code']);
             $addressInput['country_id'] = $addressInput['country_code'];
         }

--- a/app/code/Magento/QuoteGraphQl/Model/Cart/QuoteAddressFactory.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/QuoteAddressFactory.php
@@ -65,8 +65,7 @@ class QuoteAddressFactory
             throw new GraphQlInputException(
                 __('Required parameter "country_code" is missing')
             );
-        }
-        else {
+        } else {
             $addressInput['country_code'] = strtoupper($addressInput['country_code']);
             $addressInput['country_id'] = $addressInput['country_code'];
         }

--- a/app/code/Magento/QuoteGraphQl/Model/Cart/QuoteAddressFactory.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/QuoteAddressFactory.php
@@ -63,7 +63,7 @@ class QuoteAddressFactory
         $addressInput['country_id'] = '';
         if (!isset($addressInput['country_code'])) {
             throw new GraphQlInputException(
-                __('"Required parameter "country_code" is missing')
+                __('Required parameter "country_code" is missing')
             );
         }
         else {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Made changes according to wanted result in issue. Throws error if `country_code`-parameter is missing.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/graphql-ce#1041: Notice: Undefined index: country_code

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set a shipping adress without `country_code`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
See comment/question in issue: https://github.com/magento/graphql-ce/issues/1041#issuecomment-548597231

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
