### PR TITLE
magento/graphql-ce# Remove redundant logic in createCustomer mutation

### DIFF
--- a/app/code/Magento/CustomerGraphQl/Model/Resolver/CreateCustomer.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Resolver/CreateCustomer.php
@@ -63,10 +63,6 @@ class CreateCustomer implements ResolverInterface
         array $value = null,
         array $args = null
     ) {
-        if (empty($args['input']) || !is_array($args['input'])) {
-            throw new GraphQlInputException(__('"input" value should be specified'));
-        }
-
         if (!$this->newsLetterConfig->isActive(ScopeInterface::SCOPE_STORE)) {
             $args['input']['is_subscribed'] = false;
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

PR removes the redundant logic in `createCustomer` mutation because `input` param is under  `GraphQL\Validator\DocumentValidator`::`visitUsingRules` control. So, the removed logic statement will be never called.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
