### PR TITLE
magento/graphql-ce#: deleteCustomerAddress. [Test coverage] Address "id" value should be specified.

### DIFF
--- a/app/code/Magento/CustomerGraphQl/Model/Resolver/DeleteCustomerAddress.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Resolver/DeleteCustomerAddress.php
@@ -58,10 +58,6 @@ class DeleteCustomerAddress implements ResolverInterface
             throw new GraphQlAuthorizationException(__('The current customer isn\'t authorized.'));
         }
 
-        if (empty($args['id'])) {
-            throw new GraphQlInputException(__('Address "id" value should be specified'));
-        }
-
         $address = $this->getCustomerAddress->execute((int)$args['id'], $context->getUserId());
         $this->deleteCustomerAddress->execute($address);
         return true;

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/DeleteCustomerAddressTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/DeleteCustomerAddressTest.php
@@ -229,28 +229,6 @@ MUTATION;
      * @magentoApiDataFixture Magento/Customer/_files/customer_two_addresses.php
      *
      * @expectedException Exception
-     * @expectedExceptionMessage Address "id" value should be specified
-     */
-    public function testDeleteCustomerAddressWithZeroAddressEntityId()
-    {
-        $userName = 'customer@example.com';
-        $password = 'password';
-        $addressId = 0;
-
-        $mutation
-            = <<<MUTATION
-mutation {
-  deleteCustomerAddress(id: {$addressId})
-}
-MUTATION;
-        $this->graphQlMutation($mutation, [], '', $this->getCustomerAuthHeaders($userName, $password));
-    }
-
-    /**
-     * @magentoApiDataFixture Magento/Customer/_files/customer.php
-     * @magentoApiDataFixture Magento/Customer/_files/customer_two_addresses.php
-     *
-     * @expectedException Exception
      * @expectedExceptionMessage The account is locked
      */
     public function testDeleteCustomerAddressIfAccountIsLocked()

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/DeleteCustomerAddressTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/DeleteCustomerAddressTest.php
@@ -229,6 +229,28 @@ MUTATION;
      * @magentoApiDataFixture Magento/Customer/_files/customer_two_addresses.php
      *
      * @expectedException Exception
+     * @expectedExceptionMessage Address "id" value should be specified
+     */
+    public function testDeleteCustomerAddressWithZeroAddressEntityId()
+    {
+        $userName = 'customer@example.com';
+        $password = 'password';
+        $addressId = 0;
+
+        $mutation
+            = <<<MUTATION
+mutation {
+  deleteCustomerAddress(id: {$addressId})
+}
+MUTATION;
+        $this->graphQlMutation($mutation, [], '', $this->getCustomerAuthHeaders($userName, $password));
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/Customer/_files/customer_two_addresses.php
+     *
+     * @expectedException Exception
      * @expectedExceptionMessage The account is locked
      */
     public function testDeleteCustomerAddressIfAccountIsLocked()


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

PR provides a test coverage for the `Address "id" value should be specified` test case.

Source: [Magento\CustomerGraphQl\Model\Resolver\DeleteCustomerAddress::resolve()](https://github.com/magento/magento2/blob/2.3.3/app/code/Magento/CustomerGraphQl/Model/Resolver/DeleteCustomerAddress.php#L62)

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)

Thank you!